### PR TITLE
when in 2.4.0, we staid on it

### DIFF
--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -71,9 +71,9 @@ class Updater extends \common_ext_ExtensionUpdater
 
             $extension->unsetConfig('deliveryRunner');
 
-            $this->setVersion('2.4.1');
+            $this->setVersion('2.4.0');
         }
 
-        $this->skip('2.4.1', '2.7.0');
+        $this->skip('2.4.0', '2.7.0');
     }
 }


### PR DESCRIPTION
https://github.com/oat-sa/extension-tao-ltideliveryprovider/pull/67 just leave this extension in 2.4.0 forever