### PR TITLE
Fix/tao 4128 test launch lti

### DIFF
--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -129,7 +129,9 @@ class DeliveryTool extends taoLti_actions_ToolModule
         }
 
         if ($active !== null) {//resume delivery execution
-            return _url('runDeliveryExecution', 'DeliveryRunner', null, array('deliveryExecution' => $active->getIdentifier()));
+            return _url('awaitingAuthorization', 'DeliveryServer', 'ltiProctoring', [
+                'deliveryExecution' => $active->getIdentifier()
+            ]);
         }
 
         $assignmentService = $this->getServiceManager()->get(LtiAssignment::LTI_SERVICE_ID);

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '3.0.0',
+    'version' => '3.0.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'tao' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -74,6 +74,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.4.0');
         }
 
-        $this->skip('2.4.0', '3.0.0');
+        $this->skip('2.4.0', '3.0.1');
     }
 }


### PR DESCRIPTION
@jbout, per [TAO-4128](https://oat-sa.atlassian.net/browse/TAO-4128), the desire appears to be that lti test takers always launch executions from the awaiting authorization page.