### PR TITLE
Add delivery uri to LTI link during launch

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -30,5 +30,6 @@ $todefine = array(
     'PROPERTY_LTI_DEL_EXEC_LINK_USER'	=> 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LinkDeliveryExecutionUser',
     'PROPERTY_LTI_DEL_EXEC_LINK_LINK'	=> 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LinkDeliveryExecutionLink',
     'PROPERTY_LTI_DEL_EXEC_LINK_EXEC_ID'=> 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LinkDeliveryExecutionExecution',
+    'PROPERTY_LTI_DEL_EXEC_LINK_DELIVERY_ID'=> 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LinkDelivery',
 );
 ?>

--- a/install/ontology/deliverytool.rdf
+++ b/install/ontology/deliverytool.rdf
@@ -41,6 +41,12 @@
   </rdf:Description>
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOLTI.rdf#LinkDeliveryExecutionExecution">
     <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Linked delivery execution]]></rdfs:label>
+    <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#LinkDeliveryExecution"/>
+    <rdfs:range rdf:resource="http://www.tao.lu/Ontologies/TAODelivery.rdf#Delivery"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOLTI.rdf#LinkDelivery">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
     <rdfs:label xml:lang="en-US"><![CDATA[Linked delivery]]></rdfs:label>
     <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#LinkDeliveryExecution"/>
     <rdfs:range rdf:resource="http://www.tao.lu/Ontologies/TAODelivery.rdf#Delivery"/>

--- a/manifest.php
+++ b/manifest.php
@@ -22,14 +22,13 @@ use oat\taoLti\models\classes\LtiRoles;
 use oat\tao\model\user\TaoRoles;
 use oat\ltiDeliveryProvider\controller\DeliveryRunner;
 use oat\ltiDeliveryProvider\controller\LinkConfiguration;
-use oat\taoDeliveryRdf\controller\DeliveryMgmt;
 
 return array(
     'name' => 'ltiDeliveryProvider',
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '3.0.0',
+    'version' => '3.0.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'tao' => '>=9.0.0',

--- a/model/LTIDeliveryTool.php
+++ b/model/LTIDeliveryTool.php
@@ -58,7 +58,8 @@ class LTIDeliveryTool extends taoLti_models_classes_LtiTool {
 	    $link = $class->createInstanceWithProperties(array(
 	        PROPERTY_LTI_DEL_EXEC_LINK_USER => $userUri,
 	        PROPERTY_LTI_DEL_EXEC_LINK_LINK => $link,
-            PROPERTY_LTI_DEL_EXEC_LINK_EXEC_ID => $deliveryExecution
+            PROPERTY_LTI_DEL_EXEC_LINK_EXEC_ID => $deliveryExecution,
+            PROPERTY_LTI_DEL_EXEC_LINK_DELIVERY_ID => $deliveryExecution->getDelivery()->getUri(),
 	    ));
 	    return $link instanceof core_kernel_classes_Resource;
 	}
@@ -108,7 +109,8 @@ class LTIDeliveryTool extends taoLti_models_classes_LtiTool {
 	    $class->createInstanceWithProperties(array(
 	        PROPERTY_LTI_DEL_EXEC_LINK_USER => $user->getIdentifier(),
 	        PROPERTY_LTI_DEL_EXEC_LINK_LINK => $link,
-	        PROPERTY_LTI_DEL_EXEC_LINK_EXEC_ID => $deliveryExecution->getIdentifier()
+	        PROPERTY_LTI_DEL_EXEC_LINK_EXEC_ID => $deliveryExecution->getIdentifier(),
+            PROPERTY_LTI_DEL_EXEC_LINK_DELIVERY_ID => $delivery->getUri(),
 	    ));
 	    return $deliveryExecution;
 	}

--- a/model/execution/implementation/LtiDeliveryExecutionService.php
+++ b/model/execution/implementation/LtiDeliveryExecutionService.php
@@ -53,6 +53,7 @@ class LtiDeliveryExecutionService extends ConfigurableService implements LtiDeli
         $links = $class->searchInstances([
             PROPERTY_LTI_DEL_EXEC_LINK_USER => $userId,
             PROPERTY_LTI_DEL_EXEC_LINK_LINK => $link,
+            PROPERTY_LTI_DEL_EXEC_LINK_DELIVERY_ID => $delivery->getUri(),
         ], [
             'like' => false
         ]);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -74,6 +74,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.4.0');
         }
 
-        $this->skip('2.4.0', '3.0.0');
+        $this->skip('2.4.0', '3.0.1');
     }
 }


### PR DESCRIPTION
This fix solves two issues:
If LTI user has delivery executions and delivery was deleted then he will get 500 error during launch of new delivery execution (during `$deliveryExecution->getDelivery()` call):
https://github.com/oat-sa/extension-tao-ltideliveryprovider/blob/develop/model/execution/implementation/LtiDeliveryExecutionService.php#L63

The second issue is that if user has a lot of delivery executions it will impact on performance, because all his executions will be retrieved here:
https://github.com/oat-sa/extension-tao-ltideliveryprovider/blob/develop/model/execution/implementation/LtiDeliveryExecutionService.php#L54

additional filtering by delivery identifier will reduce amount of found links.