### PR TITLE
After re-indexing, delivery results filtering by lti fields (e.g. Reg…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -35,7 +35,8 @@ return array(
         'taoDeliveryRdf' => '>=1.0',
         'taoLti' => '>=5.0.0',
         'taoResultServer' => '>=5.0.0',
-        'taoDelivery' => '>=9.0.0'
+        'taoDelivery' => '>=9.0.0',
+        'taoOutcomeUi' => '>=5.3.1'
     ),
     'models' => array(
          'http://www.tao.lu/Ontologies/TAOLTI.rdf',

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '5.2.0',
+    'version' => '5.3.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'generis' => '>=5.2.0',
@@ -47,7 +47,8 @@ return array(
             \oat\ltiDeliveryProvider\scripts\install\RegisterLtiResultAliasStorage::class,
             \oat\ltiDeliveryProvider\scripts\install\RegisterServices::class,
             \oat\ltiDeliveryProvider\install\RegisterLaunchAction::class,
-            \oat\ltiDeliveryProvider\scripts\install\RegisterLtiLaunchDataService::class
+            \oat\ltiDeliveryProvider\scripts\install\RegisterLtiLaunchDataService::class,
+            \oat\ltiDeliveryProvider\scripts\install\OverrideResultCustomFieldsService::class,
         ),
         'rdf' => array(
             dirname(__FILE__). '/install/ontology/deliverytool.rdf'

--- a/model/LtiResultCustomFieldsService.php
+++ b/model/LtiResultCustomFieldsService.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\ltiDeliveryProvider\model;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoOutcomeUi\model\search\ResultCustomFieldsService;
+use oat\taoProctoring\model\deliveryLog\DeliveryLog;
+
+/**
+ * Class LtiResultCustomFieldsService
+ * @package oat\taoOutcomeUi\model\search
+ */
+class LtiResultCustomFieldsService extends ResultCustomFieldsService
+{
+    /**
+     * @param DeliveryExecutionInterface $deliveryExecution
+     * @return array
+     * @throws \common_exception_NotFound
+     */
+    public function getCustomFields(DeliveryExecutionInterface $deliveryExecution)
+    {
+        $body = parent::getCustomFields($deliveryExecution);
+
+        /** @var DeliveryLog $deliveryLog */
+        $deliveryLog = $this->getServiceLocator()->get(DeliveryLog::SERVICE_ID);
+        $data = $deliveryLog->get(
+            $deliveryExecution->getIdentifier(),
+            'LTI_DELIVERY_EXECUTION_CREATED'
+        );
+
+        if ($data) {
+            $data = current($data);
+            if (isset($data['data'])) {
+                $body = array_merge($body, $data['data']);
+            }
+        }
+
+        return $body;
+    }
+}

--- a/model/LtiResultCustomFieldsService.php
+++ b/model/LtiResultCustomFieldsService.php
@@ -16,6 +16,7 @@
  *
  * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
  *
+ * @author Ilya Yarkavets <ilya.yarkavets@1pt.com>
  */
 
 namespace oat\ltiDeliveryProvider\model;

--- a/scripts/install/OverrideResultCustomFieldsService.php
+++ b/scripts/install/OverrideResultCustomFieldsService.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018  (original work) Open Assessment Technologies SA;
+ *
+ * @author Alexander Zagovorichev <zagovorichev@1pt.com>
+ */
+
+namespace oat\ltiDeliveryProvider\scripts\install;
+
+use oat\ltiDeliveryProvider\model\LtiResultCustomFieldsService;
+use oat\oatbox\extension\InstallAction;
+use oat\taoOutcomeUi\model\search\ResultCustomFieldsService;
+
+class OverrideResultCustomFieldsService extends InstallAction
+{
+    public function __invoke($params)
+    {
+        /** @var ResultCustomFieldsService $resultCustomFieldsService */
+        $resultCustomFieldsService = $this->getServiceLocator()->get(ResultCustomFieldsService::SERVICE_ID);
+        $ltiResultCustomFieldsService = new LtiResultCustomFieldsService($resultCustomFieldsService->getOptions());
+        $this->getServiceManager()->register(LtiResultCustomFieldsService::SERVICE_ID, $ltiResultCustomFieldsService);
+    }
+}

--- a/scripts/install/OverrideResultCustomFieldsService.php
+++ b/scripts/install/OverrideResultCustomFieldsService.php
@@ -16,7 +16,7 @@
  *
  * Copyright (c) 2018  (original work) Open Assessment Technologies SA;
  *
- * @author Alexander Zagovorichev <zagovorichev@1pt.com>
+ * @author Ilya Yarkavets <ilya.yarkavets@1pt.com>
  */
 
 namespace oat\ltiDeliveryProvider\scripts\install;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -21,6 +21,7 @@ use oat\ltiDeliveryProvider\model\execution\implementation\LtiDeliveryExecutionS
 use oat\ltiDeliveryProvider\model\LtiAssignment;
 use oat\ltiDeliveryProvider\model\LtiLaunchDataService;
 use oat\ltiDeliveryProvider\model\LtiOutcomeService;
+use oat\ltiDeliveryProvider\model\LtiResultCustomFieldsService;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\service\ServiceNotFoundException;
 use oat\ltiDeliveryProvider\model\LtiResultAliasStorage;
@@ -34,6 +35,7 @@ use oat\ltiDeliveryProvider\model\actions\GetActiveDeliveryExecution;
 use oat\tao\model\actionQueue\ActionQueue;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
+use oat\taoOutcomeUi\model\search\ResultCustomFieldsService;
 use oat\taoResultServer\models\classes\ResultService;
 
 class Updater extends \common_ext_ExtensionUpdater
@@ -176,6 +178,15 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         $this->skip('4.0.0', '5.2.0');
+
+        if ($this->isVersion('5.2.0')) {
+
+            /** @var ResultCustomFieldsService $resultCustomFieldsService */
+            $resultCustomFieldsService = $this->getServiceManager()->get(ResultCustomFieldsService::SERVICE_ID);
+            $ltiResultCustomFieldsService = new LtiResultCustomFieldsService($resultCustomFieldsService->getOptions());
+            $this->getServiceManager()->register(LtiResultCustomFieldsService::SERVICE_ID, $ltiResultCustomFieldsService);
+            $this->setVersion('5.3.0');
+        }
 
     }
 }


### PR DESCRIPTION
After re-indexing, delivery results filtering by lti fields (e.g. RegistrationID) would be available;
It is just "move-to-another-extension" of rejected oat-sa/extension-lti-proctoring#94