### PR TITLE
Fix/tao 8156/updated jquery ui css path

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '8.1.1',
+    'version' => '8.1.2',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'generis' => '>=8.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -304,6 +304,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.5.0');
         }
 
-        $this->skip('6.5.0', '8.1.1');
+        $this->skip('6.5.0', '8.1.2');
     }
 }

--- a/views/templates/learner/launchQueue.tpl
+++ b/views/templates/learner/launchQueue.tpl
@@ -9,7 +9,7 @@ use oat\tao\helpers\Layout;
         <title><?=__('Test Launch Queue');?></title>
         <?= \tao_helpers_Scriptloader::render() ?>
         <link rel="stylesheet" type="text/css" href="<?= Template::css('reset.css','tao') ?>" />
-        <link rel="stylesheet" type="text/css" href="<?= Template::css('custom-theme/jquery-ui-1.8.22.custom.css','tao') ?>" />
+        <link rel="stylesheet" type="text/css" href="<?= Template::css('custom-theme/jquery-ui-1.9.2.custom.css','tao') ?>" />
         <link rel="stylesheet" type="text/css" href="<?= Template::css('errors.css','tao') ?>" />
         <link rel="stylesheet" type="text/css" href="<?= Template::css('userError.css','tao') ?>" />
         <?= Layout::getAmdLoader(Template::js('loader/app.min.js', 'tao'), 'controller/app', get_data('client_params')) ?>

--- a/views/templates/learner/overview.tpl
+++ b/views/templates/learner/overview.tpl
@@ -7,8 +7,8 @@ use oat\tao\helpers\Template;
 <head>
 	<title><?=__('Thank you');?></title>
 	<link rel="stylesheet" type="text/css" href="<?= Template::css('reset.css','tao') ?>" />
-	<link rel="stylesheet" type="text/css" href="<?= Template::css('custom-theme/jquery-ui-1.8.22.custom.css','tao') ?>" />
-    <link rel="stylesheet" type="text/css" href="<?= Template::css('thankyou.css') ?>" />	
+	<link rel="stylesheet" type="text/css" href="<?= Template::css('custom-theme/jquery-ui-1.9.2.custom.css','tao') ?>" />
+    <link rel="stylesheet" type="text/css" href="<?= Template::css('thankyou.css') ?>" />
 </head>
 
 <body>

--- a/views/templates/learner/thankYou.tpl
+++ b/views/templates/learner/thankYou.tpl
@@ -7,7 +7,7 @@ use oat\tao\helpers\Template;
 <head>
 	<title><?=__('Thank you');?></title>
     <link rel="stylesheet" href="<?= Template::css('reset.css','tao') ?>" />
-	<link rel="stylesheet" href="<?= Template::css('custom-theme/jquery-ui-1.8.22.custom.css','tao') ?>" />
+	<link rel="stylesheet" href="<?= Template::css('custom-theme/jquery-ui-1.9.2.custom.css','tao') ?>" />
     <link rel="stylesheet" href="<?= Template::css('thankyou.css') ?>" />
 	<link rel="shortcut icon" href="<?= Template::img('favicon.ico', 'tao') ?>"/>
 


### PR DESCRIPTION
task https://oat-sa.atlassian.net/browse/TAO-8156

- replaced `jquery-ui-1.8.22` which is not exists anymore by `jquery-ui-1.9.2` (new version of library)