### PR TITLE
Fix/tao 8242 serialize spawning execution action

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,10 +27,10 @@ return array(
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '8.1.2',
+    'version' => '9.0.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
-        'generis' => '>=8.0.0',
+        'generis' => '>=11.2.0',
         'tao' => '>=21.0.0',
         'taoDeliveryRdf' => '>=6.0.0',
         'taoLti' => '>=7.0.0',

--- a/model/LTIDeliveryTool.php
+++ b/model/LTIDeliveryTool.php
@@ -27,13 +27,13 @@ use oat\taoLti\models\classes\LtiTool;
 use \core_kernel_classes_Property;
 use \core_kernel_classes_Resource;
 use oat\oatbox\user\User;
+use oat\oatbox\mutex\LockTrait;
 use oat\ltiDeliveryProvider\model\execution\LtiDeliveryExecutionService;
 use oat\taoDelivery\model\execution\StateServiceInterface;
 use oat\ltiDeliveryProvider\controller\DeliveryTool;
 use oat\taoLti\models\classes\LtiMessages\LtiMessage;
 use oat\taoDelivery\model\authorization\AuthorizationService;
 use oat\taoDelivery\model\authorization\AuthorizationProvider;
-use oat\tao\model\mutex\LockTrait;
 
 class LTIDeliveryTool extends LtiTool {
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -304,6 +304,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.5.0');
         }
 
-        $this->skip('6.5.0', '8.1.2');
+        $this->skip('6.5.0', '9.0.0');
     }
 }


### PR DESCRIPTION
To prevent duplicates of delivery executions in case of multiple simultaneous requests it's necessary to serialize that action.

To test that please make sure that you have correct configuration of `oat\oatbox\mutex\LockService` service. For you local environment you may use Flock storage. It should look somehow like this:

```
return new oat\oatbox\mutex\LockService(array(
    'persistence_class' => Symfony\Component\Lock\Store\FlockStore::class,
    'persistence_options' => '{path\to\existent\folder}',
));
```

Then do the following steps:

1. open LTI tool and fill the necessary fields. Add custom options `max_attempts=1`
2. put breakpoint on line 118 of `model/LTIDeliveryTool.php`
3. Press launch on LTI tool. Make sure that execution stopped at that breakpoint
4. Press launch on LTI tool again.
5. Release breakpoint.

By doing this steps on develop branch two execution will be created despite only one attempt allowed

With changes from that PR there will no duplicated delivery execution.