### PR TITLE
TAO-8594.Feature.Delivery execution status as param in return LTI url

### DIFF
--- a/config/default/LtiNavigation.conf.php
+++ b/config/default/LtiNavigation.conf.php
@@ -1,4 +1,5 @@
 <?php
+
 use oat\ltiDeliveryProvider\model\navigation\LtiNavigationService;
 use oat\ltiDeliveryProvider\model\navigation\DefaultMessageFactory;
 
@@ -20,6 +21,7 @@ use oat\ltiDeliveryProvider\model\navigation\DefaultMessageFactory;
  * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
  */
 return new LtiNavigationService([
-    LtiNavigationService::OPTION_THANK_YOU_SCREEN => false,
-    LtiNavigationService::OPTION_MESSAGE_FACTORY => new DefaultMessageFactory()
+    LtiNavigationService::OPTION_THANK_YOU_SCREEN       => false,
+    LtiNavigationService::OPTION_DELIVERY_RETURN_STATUS => false,
+    LtiNavigationService::OPTION_MESSAGE_FACTORY        => new DefaultMessageFactory()
 ]);

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '9.0.0',
+    'version' => '9.1.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'generis' => '>=11.2.0',

--- a/model/navigation/LtiNavigationService.php
+++ b/model/navigation/LtiNavigationService.php
@@ -30,6 +30,8 @@ class LtiNavigationService extends ConfigurableService
 {
     const SERVICE_ID = 'ltiDeliveryProvider/LtiNavigation';
 
+    const OPTION_DELIVERY_RETURN_STATUS = 'delivery_return_status';
+
     const OPTION_MESSAGE_FACTORY = 'message';
 
     /**
@@ -37,6 +39,16 @@ class LtiNavigationService extends ConfigurableService
      */
     const OPTION_THANK_YOU_SCREEN = 'thankyouScreen';
 
+
+    /**
+     * @param LtiLaunchData $launchData
+     * @param DeliveryExecutionInterface $deliveryExecution
+     * @return string
+     * @throws \common_exception_NotFound
+     * @throws \oat\oatbox\service\exception\InvalidService
+     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
+     * @throws \oat\taoLti\models\classes\LtiException
+     */
     public function getReturnUrl(LtiLaunchData $launchData, DeliveryExecutionInterface $deliveryExecution)
     {
         return $this->showThankyou($launchData)
@@ -44,6 +56,15 @@ class LtiNavigationService extends ConfigurableService
             : $this->getConsumerReturnUrl($launchData, $deliveryExecution);
     }
 
+    /**
+     * @param LtiLaunchData $launchData
+     * @param DeliveryExecutionInterface $deliveryExecution
+     * @return string
+     * @throws \common_exception_NotFound
+     * @throws \oat\oatbox\service\exception\InvalidService
+     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
+     * @throws \oat\taoLti\models\classes\LtiException
+     */
     protected function getConsumerReturnUrl(LtiLaunchData $launchData, DeliveryExecutionInterface $deliveryExecution)
     {
         $urlParts = parse_url($launchData->getReturnUrl());
@@ -61,6 +82,14 @@ class LtiNavigationService extends ConfigurableService
         return $urlParts['scheme'] . '://' . $urlParts['host'] . $port . $urlParts['path'] . '?' . $urlParts['query'];
     }
 
+    /**
+     * @param LtiLaunchData $launchData
+     * @param DeliveryExecutionInterface $deliveryExecution
+     * @return array
+     * @throws \common_exception_NotFound
+     * @throws \oat\oatbox\service\exception\InvalidService
+     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
+     */
     protected function getConsumerReturnParams(LtiLaunchData $launchData, DeliveryExecutionInterface $deliveryExecution)
     {
         $ltiMessage = $this->getSubService(self::OPTION_MESSAGE_FACTORY)->getLtiMessage($deliveryExecution);
@@ -69,6 +98,9 @@ class LtiNavigationService extends ConfigurableService
             : []
         ;
         $params['deliveryExecution'] = $deliveryExecution->getIdentifier();
+        if ($this->getOption(self::OPTION_DELIVERY_RETURN_STATUS)){
+            $params['deliveryExecutionStatus'] = $deliveryExecution->getState()->getLabel();
+        }
         return $params;
     }
 
@@ -101,8 +133,8 @@ class LtiNavigationService extends ConfigurableService
                 case 'false':
                     return true;
                 default:
-                    $this->logWarning('Unexpected value for \''.DeliveryTool::PARAM_SKIP_THANKYOU.'\': '
-                        .$launchData->getVariable(DeliveryTool::PARAM_SKIP_THANKYOU));
+                    $this->logWarning('Unexpected value for \'' . DeliveryTool::PARAM_SKIP_THANKYOU . '\': '
+                        . $launchData->getVariable(DeliveryTool::PARAM_SKIP_THANKYOU));
             }
         }
         return $this->getOption(self::OPTION_THANK_YOU_SCREEN);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -305,5 +305,13 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         $this->skip('6.5.0', '9.0.0');
+        if ($this->isVersion('9.0.0')) {
+            $service = $this->getServiceManager()->get(LtiNavigationService::SERVICE_ID);
+            if(!$service->getOption(LtiNavigationService::OPTION_DELIVERY_RETURN_STATUS)){
+                $service->setOption(LtiNavigationService::OPTION_DELIVERY_RETURN_STATUS, false);
+                $this->getServiceManager()->register(LtiNavigationService::SERVICE_ID, $service);
+            }
+            $this->setVersion('9.1.0');
+        }
     }
 }


### PR DESCRIPTION
Configurable option to send delivery execution status in LTI return url. Detailed: https://oat-sa.atlassian.net/browse/TAO-8594
By default it is disabled.
To test it in work:
1 - \oat\ltiDeliveryProvider\model\navigation\LtiNavigationService  delivery_return_status=>true.
2 - pass any LTI test with return url. 