### PR TITLE
Fix/tao 8227/fix to escape html

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '9.0.0',
+    'version' => '9.0.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'generis' => '>=11.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -304,6 +304,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.5.0');
         }
 
-        $this->skip('6.5.0', '9.0.0');
+        $this->skip('6.5.0', '9.0.1');
     }
 }

--- a/views/templates/instructor/viewDelivery.tpl
+++ b/views/templates/instructor/viewDelivery.tpl
@@ -11,7 +11,7 @@
 <body class="tao-scope">
     <div style="padding: 0 0 10px 0">
     	<?= has_data('linkTitle')
-    	   ? __('"%s" has been configured:', get_data('linkTitle'))
+    	   ? __('"%s" has been configured:', _dh(get_data('linkTitle')))
     	   : __('This tool has been configured:')?>
     </div>
 
@@ -19,7 +19,7 @@
         <div class="col-3">
             <table class="matrix">
                 <tbody>
-                <tr><th><?=__('Selected Delivery');?></th><td><?= get_data('delivery')->getLabel()?></td></tr>
+                <tr><th><?=__('Selected Delivery');?></th><td><?= _dh(get_data('delivery')->getLabel())?></td></tr>
                 <?php if(has_data('executionCount')) :?>
                 <tr><th><?=__('Executions');?></th><td><?= get_data('executionCount')?></td></tr>
                 <?php else :?>

--- a/views/templates/linkManagement.tpl
+++ b/views/templates/linkManagement.tpl
@@ -4,7 +4,7 @@ use oat\tao\helpers\Template;
 
 
 <div class="main-container flex-container-main-form">
-    <h2><?=__('%s Tool Provider', get_data('deliveryLabel'))?></h2>
+    <h2><?=__('%s Tool Provider', _dh(get_data('deliveryLabel')))?></h2>
     <div id="form-container" class="form-content">
         <div class="xhtml_form">
             <form>


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/TAO-8227

Saving the label of delivery was fixed before, so the input field escapes characters properly, but we have some issues still with the way how we require data upon template generation.

This PR fixes the listed issues in the jira ticket.

Steps to reproduce:
1. login as admin
2. install ltiDeliveryProvider
2. create a test and a delivery
3. put some xss code for delivery label and save the form

Experienced:
- by clicking on LTI button (on the left panel to be able to see the launch url) the previously injected script runs
- by running the delivery through lti (with http://ltiapps.net/test/tc.php tool as instructor) it runs the script
- by putting on the http://ltiapps.net/test/tc.php tool the xss script as resource title and launch the lti it runs the script as well
