### PR TITLE
Feature/nex 319/add lis parameters

### DIFF
--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -211,7 +211,7 @@ class DeliveryTool extends ToolModule
      * @throws LtiException
      * @throws \common_exception_Error
      */
-    private function getDelivery()
+    protected function getDelivery()
     {
         $returnValue = null;
         //passed as aprameter

--- a/manifest.php
+++ b/manifest.php
@@ -27,13 +27,13 @@ return array(
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '9.4.1',
+    'version' => '9.5.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'generis' => '>=11.2.0',
         'tao' => '>=21.0.0',
         'taoDeliveryRdf' => '>=6.0.0',
-        'taoLti' => '>=7.0.0',
+        'taoLti' => '>=10.5.0',
         'taoResultServer' => '>=7.0.0',
         'taoDelivery' => '>=11.0.0',
         'taoOutcomeUi' => '>=7.0.0'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -324,6 +324,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(LTIDeliveryToolFactory::SERVICE_ID, new LTIDeliveryToolFactory());
             $this->setVersion('9.4.0');
         }
-        $this->skip('9.4.0', '9.4.1');
+        $this->skip('9.4.0', '9.5.0');
     }
 }

--- a/test/integration/controller/DeliveryToolTest.php
+++ b/test/integration/controller/DeliveryToolTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\ltiDeliveryProvider\test\integration\controller;
+
+use common_http_Request;
+use oat\generis\test\TestCase;
+use oat\ltiDeliveryProvider\controller\DeliveryTool;
+use oat\taoLti\models\classes\LtiLaunchData;
+
+class DeliveryToolTest extends TestCase
+{
+    public function testBuildLaunchDataTest()
+    {
+        \common_Config::load();
+
+        $request = new \common_http_Request(
+            'http://test.it/tao/tao/tao/' . base64_encode(json_encode(['toto' => 'test']))
+        );
+
+        $resourceMock = $this->createMock(\core_kernel_classes_Resource::class);
+        $resourceMock->method('getUri')->willReturn('success');
+
+        $toolModule = new DeliveryToolMock($resourceMock);
+        $data = $toolModule->buildLaunchData($request)->jsonSerialize();
+
+        $this->assertArrayHasKey('variables', $data);
+        $this->assertArrayHasKey(LtiLaunchData::LIS_OUTCOME_SERVICE_URL, $data['variables']);
+        $this->assertEquals(_url('manageResults', 'ResultController', 'taoLtiConsumer'), $data['variables'][LtiLaunchData::LIS_OUTCOME_SERVICE_URL]);
+        $this->assertArrayHasKey(LtiLaunchData::LIS_RESULT_SOURCEDID, $data['variables']);
+        $this->assertEquals('success', $data['variables'][LtiLaunchData::LIS_RESULT_SOURCEDID]);
+    }
+
+}
+
+class DeliveryToolMock extends DeliveryTool
+{
+    private $delivery;
+
+    public function __construct($delivery)
+    {
+        $this->delivery = $delivery;
+    }
+
+    public function run()
+    {
+    }
+
+    public function buildLaunchData(common_http_Request $request)
+    {
+        return parent::buildLaunchData($request);
+    }
+
+    public function getDelivery()
+    {
+        return $this->delivery;
+    }
+
+}


### PR DESCRIPTION
Requires https://github.com/oat-sa/extension-tao-lti/pull/198

Override lti launch data build to add lis_outcome_service_url & lis_result_sourcedid