### PR TITLE
TTD-18 Tests extends from `generis\test\TestCase`. All mock objects e…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'version' => '9.7.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
-        'generis' => '>=11.2.0',
+        'generis' => '>=12.5.0',
         'tao' => '>=21.0.0',
         'taoDeliveryRdf' => '>=6.0.0',
         'taoLti' => '>=10.5.0',

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '9.7.0',
+    'version' => '10.0.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '9.6.0',
+    'version' => '9.7.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'generis' => '>=11.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -324,6 +324,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(LTIDeliveryToolFactory::SERVICE_ID, new LTIDeliveryToolFactory());
             $this->setVersion('9.4.0');
         }
-        $this->skip('9.4.0', '9.7.0');
+        $this->skip('9.4.0', '10.0.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -324,6 +324,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(LTIDeliveryToolFactory::SERVICE_ID, new LTIDeliveryToolFactory());
             $this->setVersion('9.4.0');
         }
-        $this->skip('9.4.0', '9.6.0');
+        $this->skip('9.4.0', '9.7.0');
     }
 }

--- a/test/unit/model/LtiAssignmentTest.php
+++ b/test/unit/model/LtiAssignmentTest.php
@@ -30,6 +30,7 @@ use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiLaunchData;
 use oat\taoLti\models\classes\TaoLtiSession;
 use Psr\Log\LoggerInterface;
+use oat\generis\test\MockObject;
 
 /**
  * Class LtiAssignmentAuthorizationServiceTest
@@ -40,25 +41,25 @@ class LtiAssignmentTest extends TestCase
     /** @var LtiAssignment */
     private $object;
 
-    /** @var SessionService|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var SessionService|MockObject */
     private $sessionServiceMock;
 
-    /** @var AttemptServiceInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var AttemptServiceInterface|MockObject */
     private $attemptServiceMock;
 
-    /** @var User|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var User|MockObject */
     private $userMock;
 
-    /** @var \core_kernel_classes_Resource|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \core_kernel_classes_Resource|MockObject */
     private $deliveryMock;
 
-    /** @var \common_session_Session|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \common_session_Session|MockObject */
     private $sessionMock;
 
-    /** @var LtiLaunchData|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var LtiLaunchData|MockObject */
     private $launchDataMock;
 
-    /** @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var LoggerInterface|MockObject */
     private $loggerMock;
 
     /**

--- a/test/unit/model/navigation/LtiNavigationServiceTest.php
+++ b/test/unit/model/navigation/LtiNavigationServiceTest.php
@@ -23,6 +23,7 @@ use oat\ltiDeliveryProvider\model\navigation\LtiNavigationService;
 use oat\generis\test\TestCase;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoLti\models\classes\LtiLaunchData;
+use oat\generis\test\MockObject;
 
 /**
  * Class LtiNavigationServiceTest
@@ -31,17 +32,17 @@ use oat\taoLti\models\classes\LtiLaunchData;
 class LtiNavigationServiceTest extends TestCase
 {
     /**
-     * @var LtiNavigationService|\PHPUnit_Framework_MockObject_MockObject
+     * @var LtiNavigationService|MockObject
      */
     private $object;
 
     /**
-     * @var LtiLaunchData|\PHPUnit_Framework_MockObject_MockObject
+     * @var LtiLaunchData|MockObject
      */
     private $launchDataMock;
 
     /**
-     * @var DeliveryExecutionInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DeliveryExecutionInterface|MockObject
      */
     private $deliveryExecutionMock;
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.