### PR TITLE
Backport/nfersup 40/sprint111 create lti result link on delivery execution created

### DIFF
--- a/controller/DeliveryRunner.php
+++ b/controller/DeliveryRunner.php
@@ -29,7 +29,6 @@ use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiLaunchData;
 use oat\taoLti\models\classes\LtiService;
 use oat\taoLti\models\classes\theme\LtiHeadless;
-use oat\ltiDeliveryProvider\model\LtiResultAliasStorage;
 use oat\ltiDeliveryProvider\model\LTIDeliveryTool;
 use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
 use oat\taoDelivery\model\execution\DeliveryExecution;
@@ -168,27 +167,4 @@ class DeliveryRunner extends DeliveryServer
         $state = $deliveryExecution->getState()->getLabel();
         return new LtiMessage($state, null);
     }
-
-    /**
-     * @param $compiledDelivery
-     * @param $executionIdentifier
-     * @param $userId
-     * @throws LtiException
-     * @throws \common_exception_Error
-     * @throws \oat\taoLti\models\classes\LtiVariableMissingException
-     */
-    protected function initResultServer($compiledDelivery, $executionIdentifier, $userId)
-    {
-        // lis_outcome_service_url This value should not change from one launch to the next and in general,
-        //  the TP can expect that there is a one-to-one mapping between the lis_outcome_service_url and a particular oauth_consumer_key.  This value might change if there was a significant re-configuration of the TC system or if the TC moved from one domain to another.
-        $launchData = LtiService::singleton()->getLtiSession()->getLaunchData();
-        $resultIdentifier = $launchData->hasVariable('lis_result_sourcedid') ? $launchData->getVariable('lis_result_sourcedid') : $executionIdentifier;
-
-        /** @var LtiResultAliasStorage $ltiResultIdStorage */
-        $ltiResultIdStorage = $this->getServiceManager()->get(LtiResultAliasStorage::SERVICE_ID);
-        $ltiResultIdStorage->storeResultAlias($executionIdentifier, $resultIdentifier);
-
-        parent::initResultServer($compiledDelivery, $executionIdentifier, $userId);
-    }
-
 }

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '9.5.1',
+    'version' => '9.5.1.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'generis' => '>=11.2.0',

--- a/model/LtiResultAliasStorage.php
+++ b/model/LtiResultAliasStorage.php
@@ -68,7 +68,7 @@ class LtiResultAliasStorage extends ConfigurableService implements DeliveryExecu
         $queryBuilder->delete($this->getTableName());
         $queryBuilder->where(self::RESULT_ID . '=? OR ' . self::DELIVERY_EXECUTION_ID . '= ?');
         $queryBuilder->setParameters([$resultId, $deliveryExecutionId]);
-        $res = $this->persistence->query($queryBuilder->getSQL(), $queryBuilder->getParameters())->execute();
+        $this->persistence->query($queryBuilder->getSQL(), $queryBuilder->getParameters())->execute();
 
         $result = $this->getPersistence()->insert(self::TABLE_NAME, $data) === 1;
         return $result;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -324,6 +324,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(LTIDeliveryToolFactory::SERVICE_ID, new LTIDeliveryToolFactory());
             $this->setVersion('9.4.0');
         }
-        $this->skip('9.4.0', '9.5.1');
+        $this->skip('9.4.0', '9.5.1.1');
     }
 }


### PR DESCRIPTION
Backport for NFERSUP-40
Original PR: https://github.com/oat-sa/extension-tao-ltideliveryprovider/pull/221
fix prevent creating additional links or modifying existing links in table  lti_result_identifiers