### PR TITLE
Avoid deprecated method usage

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '10.1.1',
+    'version' => '10.1.2',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -324,6 +324,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(LTIDeliveryToolFactory::SERVICE_ID, new LTIDeliveryToolFactory());
             $this->setVersion('9.4.0');
         }
-        $this->skip('9.4.0', '10.1.1');
+        $this->skip('9.4.0', '10.1.2');
     }
 }

--- a/test/unit/model/LtiDeliveryFactoryTest.php
+++ b/test/unit/model/LtiDeliveryFactoryTest.php
@@ -33,7 +33,7 @@ class LtiDeliveryFactoryTest extends TestCase
         $tool = $this->getMockBuilder(LTIDeliveryTool::class)->disableOriginalConstructor()->getMock();
         $tool->expects($this->once())->method('getDeliveryFromLink')->willReturn(true);
 
-        $toolFactory = $this->getMock(LTIDeliveryToolFactory::class);
+        $toolFactory = $this->createMock(LTIDeliveryToolFactory::class);
         $toolFactory->expects($this->once())->method('create')->willReturn($tool);
 
         $serviceLocator = $this->getServiceLocatorMock(


### PR DESCRIPTION
Remove deprecated `TestCase::getMock()`.