### PR TITLE
Fix/ACTP-19/Max attempts is not applied to a test

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '10.1.5',
+    'version' => '10.1.6',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'generis' => '>=12.5.0',

--- a/model/execution/implementation/KvLTIDeliveryExecutionLink.php
+++ b/model/execution/implementation/KvLTIDeliveryExecutionLink.php
@@ -109,8 +109,10 @@ class KvLTIDeliveryExecutionLink implements LTIDeliveryExecutionLink, \JsonSeria
         $links = [];
         $data = $values !== false ? json_decode($values, true) : [];
 
-        if (isset($data['userId']) && isset($data['linkId']) && isset($data['deliveryExecutionId'])) {
-            $links[] = new self($data['userId'], $data['deliveryExecutionId'], $data['linkId']);
+        foreach ($data as $linkData) {
+            if (isset($linkData['userId']) && isset($linkData['linkId']) && isset($linkData['deliveryExecutionId'])) {
+                $links[] = new self($linkData['userId'], $linkData['deliveryExecutionId'], $linkData['linkId']);
+            }
         }
 
         return $links;

--- a/model/execution/implementation/KvLTIDeliveryExecutionLink.php
+++ b/model/execution/implementation/KvLTIDeliveryExecutionLink.php
@@ -110,7 +110,7 @@ class KvLTIDeliveryExecutionLink implements LTIDeliveryExecutionLink, \JsonSeria
         $data = $values !== false ? json_decode($values, true) : [];
 
         foreach ($data as $linkData) {
-            if (isset($linkData['userId']) && isset($linkData['linkId']) && isset($linkData['deliveryExecutionId'])) {
+            if (isset($linkData['userId'], $linkData['linkId'], $linkData['deliveryExecutionId'])) {
                 $links[] = new self($linkData['userId'], $linkData['deliveryExecutionId'], $linkData['linkId']);
             }
         }

--- a/model/execution/implementation/KvLtiDeliveryExecutionService.php
+++ b/model/execution/implementation/KvLtiDeliveryExecutionService.php
@@ -82,7 +82,8 @@ class KvLtiDeliveryExecutionService extends AbstractLtiDeliveryExecutionService
 
         $results = [];
         foreach ($ltiDeliveryExecutionLinks as $ltiDeliveryExecutionLink) {
-            $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution(
+            /** @var DeliveryExecution $deliveryExecution */
+            $deliveryExecution = $this->getServiceLocator()->get(ServiceProxy::SERVICE_ID)->getDeliveryExecution(
                 $ltiDeliveryExecutionLink->getDeliveryExecutionId()
             );
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -324,6 +324,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(LTIDeliveryToolFactory::SERVICE_ID, new LTIDeliveryToolFactory());
             $this->setVersion('9.4.0');
         }
-        $this->skip('9.4.0', '10.1.5');
+        $this->skip('9.4.0', '10.1.6');
     }
 }


### PR DESCRIPTION
Custom parameter 'max_attempts' is not applied to a test when the value > 1.
 
Related to: [https://oat-sa.atlassian.net/browse/ACTP-19](https://oat-sa.atlassian.net/browse/ACTP-19)
 
Changes: delivery execution data is added to the redis by the key instead of overwriting old data with new.
 
#### Precondition
Change your configs to use `KvLtiDeliveryExecutionService` instead of `LtiDeliveryExecutionService`

#### Steps to reproduce
- Launch a test via LTI with Custom parameter 'max_attempts' and put the value >1, for example max_attempts=2.
- Pass the test by Test-Taker 2 times.
- Launch the test 3rd time.
  
#### How to test
**Bug**: 
The test is launched, test-taker can pass the test.
**Fix**: 
Message 'Attempts limit has been reached' is appeared.