### PR TITLE
Feature/actp 282/add possibility to enable features via lti

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '10.1.6',
+    'version' => '10.2.0',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'generis' => '>=12.5.0',

--- a/model/delivery/DeliveryContainerService.php
+++ b/model/delivery/DeliveryContainerService.php
@@ -20,10 +20,12 @@
 
 namespace oat\ltiDeliveryProvider\model\delivery;
 
+use oat\oatbox\session\SessionService;
 use oat\taoDeliveryRdf\model\DeliveryContainerService as DeliveryRdfContainerService;
 use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiLaunchData;
 use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
+use oat\taoLti\models\classes\LtiVariableMissingException;
 use oat\taoLti\models\classes\TaoLtiSession;
 
 /**
@@ -34,6 +36,8 @@ use oat\taoLti\models\classes\TaoLtiSession;
 class DeliveryContainerService extends DeliveryRdfContainerService
 {
     const CUSTOM_LTI_SECURE = 'custom_secure';
+
+    const CUSTOM_LTI_TAO_FEATURES = 'custom_x_tao_features';
 
     /**
      * Validate and prepare launch variables
@@ -60,18 +64,66 @@ class DeliveryContainerService extends DeliveryRdfContainerService
     protected function getActiveFeatures(\core_kernel_classes_Resource $delivery)
     {
         $result = parent::getActiveFeatures($delivery);
-        $currentSession = \common_session_SessionManager::getSession();
+        $currentSession = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentSession();
         if ($currentSession instanceof TaoLtiSession) {
             $launchData = $currentSession->getLaunchData();
-            $this->validateLtiParams($launchData);
-            if ($launchData->hasVariable(self::CUSTOM_LTI_SECURE)) {
-                if ($launchData->getVariable(self::CUSTOM_LTI_SECURE) === 'true') {
-                    $result[] = 'security';
+            $allFeatures = $this->getAllAvailableFeatures();
+            $ltiFeatures = $this->getLtiFeaturesList($launchData);
+            $enabledLtiFeatures = [];
+            $disabledLtiFeatures = [];
+            foreach ($ltiFeatures as $featureName => $featureStatus) {
+                if (empty($allFeatures[$featureName])) {
+                    continue;
+                }
+
+                if (filter_var($featureStatus, FILTER_VALIDATE_BOOLEAN)) {
+                    $enabledLtiFeatures[] = $featureName;
                 } else {
-                    $result = array_diff($result, ['security']);
+                    $disabledLtiFeatures[] = $featureName;
                 }
             }
+
+            // TODO: Deprecated method, to be removed in version 11.0.0
+            $this->validateLtiParams($launchData);
+            if (!isset($ltiFeatures['security']) && $launchData->hasVariable(self::CUSTOM_LTI_SECURE)) {
+                if ($launchData->getVariable(self::CUSTOM_LTI_SECURE) === 'true') {
+                    $enabledLtiFeatures[] = 'security';
+                } else {
+                    $disabledLtiFeatures[] = 'security';
+                }
+            }
+
+            $result = array_merge($result, $enabledLtiFeatures);
+            $result = array_diff($result, $disabledLtiFeatures);
         }
+
         return array_unique($result);
+    }
+
+    /**
+     * @param LtiLaunchData $launchData
+     * @return array
+     */
+    private function getLtiFeaturesList(LtiLaunchData $launchData) {
+        $ltiFeatures = [];
+        try {
+            if (!$launchData->hasVariable(self::CUSTOM_LTI_TAO_FEATURES)) {
+                return $ltiFeatures;
+            }
+
+            $toolsLtiVariable = $launchData->getVariable(self::CUSTOM_LTI_TAO_FEATURES);
+            $features = json_decode($toolsLtiVariable, true);
+            if (is_array($features)) {
+                $ltiFeatures = $features;
+            }
+        } catch (LtiVariableMissingException $e) {
+            $this->logWarning('Cannot get LTI parameter: ' . self::CUSTOM_LTI_TAO_FEATURES, [
+                'message' => $e->getMessage(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ]);
+        }
+
+        return $ltiFeatures;
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -324,6 +324,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(LTIDeliveryToolFactory::SERVICE_ID, new LTIDeliveryToolFactory());
             $this->setVersion('9.4.0');
         }
-        $this->skip('9.4.0', '10.1.6');
+        $this->skip('9.4.0', '10.2.0');
     }
 }


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/ACTP-282

The goal of this PR is to add new generic LTI parameter with possibility to control all available test runner features via this parameter. Format: `x_tao_features={"security":false,"security_no_fullscreen":true}`

How to test:
- make sure you have one or more test runner features configured/activated in TAO
- try to launch LTI delivery execution with different combinations of enabled features and check features/plugins are enabled/disabled as expected