### PR TITLE
BSA-85: Override accessibility tools configuration via custom LTI parameters

### DIFF
--- a/config/default/OptionCollectionMapper.conf.php
+++ b/config/default/OptionCollectionMapper.conf.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Default config header created during install
+ */
+
+use oat\ltiDeliveryProvider\model\options\DataAccess\Mapper\OptionCollectionMapper;
+
+return new OptionCollectionMapper();

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '10.5.0',
+    'version' => '10.6.0',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'generis' => '>=12.15.0',
@@ -38,7 +38,8 @@ return [
         'taoLti' => '>=10.5.0',
         'taoResultServer' => '>=7.0.0',
         'taoDelivery' => '>=11.0.0',
-        'taoOutcomeUi' => '>=7.0.0'
+        'taoOutcomeUi' => '>=7.0.0',
+        'taoQtiTest' => '>=37.1.0',
     ],
     'models' => [
          'http://www.tao.lu/Ontologies/TAOLTI.rdf',
@@ -53,9 +54,10 @@ return [
             \oat\ltiDeliveryProvider\install\InstallDeliveryContainerService::class,
             \oat\ltiDeliveryProvider\scripts\install\RegisterLtiAttemptService::class,
             \oat\ltiDeliveryProvider\scripts\install\RegisterMetrics::class,
+            \oat\ltiDeliveryProvider\scripts\install\RegisterOverriddenLtiToolRepository::class,
         ],
         'rdf' => [
-            dirname(__FILE__) . '/install/ontology/deliverytool.rdf'
+            __DIR__ . '/install/ontology/deliverytool.rdf'
         ]
     ],
     'routes' => [
@@ -74,16 +76,16 @@ return [
     'constants' => [
 
         # views directory
-        "DIR_VIEWS"                => __DIR__ . DIRECTORY_SEPARATOR . "views" . DIRECTORY_SEPARATOR,
+        'DIR_VIEWS'           => __DIR__ . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR,
 
         # default module name
-        'DEFAULT_MODULE_NAME'    => 'Browser',
+        'DEFAULT_MODULE_NAME' => 'Browser',
 
         #default action name
-        'DEFAULT_ACTION_NAME'    => 'index',
+        'DEFAULT_ACTION_NAME' => 'index',
 
         #BASE PATH: the root path in the file system (usually the document root)
-        'BASE_PATH'                => __DIR__ . DIRECTORY_SEPARATOR ,
+        'BASE_PATH'           => __DIR__ . DIRECTORY_SEPARATOR ,
 
         #BASE URL (usually the domain root)
         'BASE_URL'                => ROOT_URL . 'ltiDeliveryProvider/',

--- a/model/options/DataAccess/Mapper/OptionCollectionMapper.php
+++ b/model/options/DataAccess/Mapper/OptionCollectionMapper.php
@@ -36,7 +36,9 @@ class OptionCollectionMapper extends ConfigurableService
         $resultingOptions = [];
 
         foreach ($rawData as $tool => $status) {
-            $resultingOptions[] = new Option((string)$tool, (bool)$status);
+            if (is_bool($status)) {
+                $resultingOptions[] = new Option((string)$tool, $status);
+            }
         }
 
         return new OptionCollection(...$resultingOptions);

--- a/model/options/DataAccess/Mapper/OptionCollectionMapper.php
+++ b/model/options/DataAccess/Mapper/OptionCollectionMapper.php
@@ -16,6 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
  */
 declare(strict_types=1);
 

--- a/model/options/DataAccess/Mapper/OptionCollectionMapper.php
+++ b/model/options/DataAccess/Mapper/OptionCollectionMapper.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\model\options\DataAccess\Mapper;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\taoQtiTest\models\runner\config\Business\Domain\Option;
+use oat\taoQtiTest\models\runner\config\Business\Domain\OptionCollection;
+
+class OptionCollectionMapper extends ConfigurableService
+{
+    public const SERVICE_ID = 'ltiDeliveryProvider/OptionCollectionMapper';
+
+    public function toDomain(array $rawData): OptionCollection
+    {
+        $resultingOptions = [];
+
+        foreach ($rawData as $tool => $status) {
+            $resultingOptions[] = new Option((string)$tool, (bool)$status);
+        }
+
+        return new OptionCollection(...$resultingOptions);
+    }
+}

--- a/model/options/DataAccess/Repository/OverriddenLtiToolsRepository.php
+++ b/model/options/DataAccess/Repository/OverriddenLtiToolsRepository.php
@@ -16,6 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
  */
 declare(strict_types=1);
 

--- a/model/options/DataAccess/Repository/OverriddenLtiToolsRepository.php
+++ b/model/options/DataAccess/Repository/OverriddenLtiToolsRepository.php
@@ -27,10 +27,10 @@ use oat\ltiDeliveryProvider\model\options\DataAccess\Mapper\OptionCollectionMapp
 use oat\oatbox\session\SessionService;
 use oat\taoLti\models\classes\TaoLtiSession;
 use oat\taoQtiTest\models\runner\config\Business\Domain\OptionCollection;
-use oat\taoQtiTest\models\runner\toolsStates\DataAccess\Repository\OverriddenToolsRepositoryAbstract;
+use oat\taoQtiTest\models\runner\toolsStates\DataAccess\Repository\AbstractOverriddenToolsRepository;
 use oat\taoQtiTest\models\TestCategoryPresetProvider;
 
-class OverriddenLtiToolsRepository extends OverriddenToolsRepositoryAbstract
+class OverriddenLtiToolsRepository extends AbstractOverriddenToolsRepository
 {
     private const CUSTOM_LTI_TAO_TOOLS = 'custom_x_tao_tools';
 

--- a/model/options/DataAccess/Repository/OverriddenLtiToolsRepository.php
+++ b/model/options/DataAccess/Repository/OverriddenLtiToolsRepository.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\model\options\DataAccess\Repository;
+
+use oat\ltiDeliveryProvider\model\options\DataAccess\Mapper\OptionCollectionMapper;
+use oat\oatbox\session\SessionService;
+use oat\taoLti\models\classes\TaoLtiSession;
+use oat\taoQtiTest\models\runner\config\Business\Domain\OptionCollection;
+use oat\taoQtiTest\models\runner\toolsStates\DataAccess\Repository\OverriddenToolsRepositoryAbstract;
+use oat\taoQtiTest\models\TestCategoryPresetProvider;
+
+class OverriddenLtiToolsRepository extends OverriddenToolsRepositoryAbstract
+{
+    private const CUSTOM_LTI_TAO_TOOLS = 'custom_x_tao_tools';
+
+    /** @var SessionService */
+    private $sessionService;
+    /** @var OptionCollectionMapper */
+    private $mapper;
+
+    public function __construct(
+        TestCategoryPresetProvider $presetRepository,
+        SessionService $sessionService,
+        OptionCollectionMapper $mapper
+    ) {
+        parent::__construct($presetRepository);
+
+        $this->sessionService = $sessionService;
+        $this->mapper         = $mapper;
+    }
+
+    protected function findAllUnfiltered(): OptionCollection
+    {
+        $session = $this->sessionService->getCurrentSession();
+
+        if (!$session instanceof TaoLtiSession) {
+            return new OptionCollection();
+        }
+
+        $launchData = $session->getLaunchData();
+
+        if (!$launchData->hasVariable(self::CUSTOM_LTI_TAO_TOOLS)) {
+            return new OptionCollection();
+        }
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $toolSettings = (array)json_decode($launchData->getVariable(self::CUSTOM_LTI_TAO_TOOLS), true);
+
+        return $this->mapper->toDomain($toolSettings);
+    }
+}

--- a/scripts/install/RegisterOverriddenLtiToolRepository.php
+++ b/scripts/install/RegisterOverriddenLtiToolRepository.php
@@ -15,9 +15,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018  (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
  *
- * @author Ilya Yarkavets <ilya.yarkavets@1pt.com>
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
  */
 
 namespace oat\ltiDeliveryProvider\scripts\install;

--- a/scripts/install/RegisterOverriddenLtiToolRepository.php
+++ b/scripts/install/RegisterOverriddenLtiToolRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018  (original work) Open Assessment Technologies SA;
+ *
+ * @author Ilya Yarkavets <ilya.yarkavets@1pt.com>
+ */
+
+namespace oat\ltiDeliveryProvider\scripts\install;
+
+use oat\ltiDeliveryProvider\model\options\DataAccess\Mapper\OptionCollectionMapper;
+use oat\ltiDeliveryProvider\model\options\DataAccess\Repository\OverriddenLtiToolsRepository;
+use oat\oatbox\extension\InstallAction;
+use oat\oatbox\session\SessionService;
+use oat\taoQtiTest\models\TestCategoryPresetProvider;
+
+class RegisterOverriddenLtiToolRepository extends InstallAction
+{
+    public function __invoke($params)
+    {
+        $serviceManager = $this->getServiceManager();
+
+        $serviceManager->register(
+            OverriddenLtiToolsRepository::SERVICE_ID,
+            new OverriddenLtiToolsRepository(
+                $serviceManager->get(TestCategoryPresetProvider::SERVICE_ID),
+                $serviceManager->get(SessionService::SERVICE_ID),
+                $serviceManager->get(OptionCollectionMapper::SERVICE_ID)
+            )
+        );
+    }
+}

--- a/test/unit/model/options/DataAccess/Mapper/OptionCollectionMapperTest.php
+++ b/test/unit/model/options/DataAccess/Mapper/OptionCollectionMapperTest.php
@@ -16,6 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
  */
 declare(strict_types=1);
 

--- a/test/unit/model/options/DataAccess/Mapper/OptionCollectionMapperTest.php
+++ b/test/unit/model/options/DataAccess/Mapper/OptionCollectionMapperTest.php
@@ -55,7 +55,7 @@ class OptionCollectionMapperTest extends TestCase
     public function dataProvider(): array
     {
         return [
-            [
+            'Valid statuses' => [
                 [
                     'opt_1' => true,
                     'opt_2' => false,
@@ -63,6 +63,18 @@ class OptionCollectionMapperTest extends TestCase
                 new OptionCollection(
                     new Option('opt_1', true),
                     new Option('opt_2', false)
+                ),
+            ],
+            'Invalid statuses' => [
+                [
+                    'opt_1' => false,
+                    'opt_2' => true,
+                    'opt_3' => 'false',
+                    'opt_4' => 'true',
+                ],
+                new OptionCollection(
+                    new Option('opt_1', false),
+                    new Option('opt_2', true)
                 ),
             ],
         ];

--- a/test/unit/model/options/DataAccess/Mapper/OptionCollectionMapperTest.php
+++ b/test/unit/model/options/DataAccess/Mapper/OptionCollectionMapperTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\test\unit\model\options\DataAccess\Mapper;
+
+use oat\generis\test\TestCase;
+use oat\ltiDeliveryProvider\model\options\DataAccess\Mapper\OptionCollectionMapper;
+use oat\taoQtiTest\models\runner\config\Business\Domain\Option;
+use oat\taoQtiTest\models\runner\config\Business\Domain\OptionCollection;
+
+class OptionCollectionMapperTest extends TestCase
+{
+    /** @var OptionCollectionMapper */
+    private $sut;
+
+    /**
+     * @before
+     */
+    public function init(): void
+    {
+        $this->sut = new OptionCollectionMapper();
+    }
+
+    /**
+     * @param array            $rawData
+     * @param OptionCollection $expected
+     *
+     * @dataProvider dataProvider
+     */
+    public function testToDomain(array $rawData, OptionCollection $expected): void
+    {
+        $this->assertEquals($expected, $this->sut->toDomain($rawData));
+    }
+
+    public function dataProvider(): array
+    {
+        return [
+            [
+                [
+                    'opt_1' => true,
+                    'opt_2' => false,
+                ],
+                new OptionCollection(
+                    new Option('opt_1', true),
+                    new Option('opt_2', false)
+                ),
+            ],
+        ];
+    }
+}

--- a/test/unit/model/options/DataAccess/Repository/OverriddenLtiToolsRepositoryTest.php
+++ b/test/unit/model/options/DataAccess/Repository/OverriddenLtiToolsRepositoryTest.php
@@ -16,6 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
  */
 declare(strict_types=1);
 

--- a/test/unit/model/options/DataAccess/Repository/OverriddenLtiToolsRepositoryTest.php
+++ b/test/unit/model/options/DataAccess/Repository/OverriddenLtiToolsRepositoryTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\test\unit\model\options\DataAccess\Repository;
+
+use common_session_Session as Session;
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\ltiDeliveryProvider\model\options\DataAccess\Mapper\OptionCollectionMapper;
+use oat\ltiDeliveryProvider\model\options\DataAccess\Repository\OverriddenLtiToolsRepository;
+use oat\oatbox\session\SessionService;
+use oat\taoLti\models\classes\LtiLaunchData;
+use oat\taoLti\models\classes\TaoLtiSession;
+use oat\taoQtiTest\models\runner\config\Business\Domain\Option;
+use oat\taoQtiTest\models\runner\config\Business\Domain\OptionCollection;
+use oat\taoQtiTest\models\TestCategoryPreset;
+use oat\taoQtiTest\models\TestCategoryPresetProvider;
+
+class OverriddenLtiToolsRepositoryTest extends TestCase
+{
+    /** @var TestCategoryPresetProvider|MockObject */
+    private $presetRepository;
+
+    /** @var SessionService|MockObject */
+    private $sessionService;
+
+    /** @var OverriddenLtiToolsRepository */
+    private $sut;
+
+    /**
+     * @before
+     */
+    public function init(): void
+    {
+        $this->presetRepository = $this->createMock(TestCategoryPresetProvider::class);
+        $this->sessionService   = $this->createMock(SessionService::class);
+
+        $this->sut = new OverriddenLtiToolsRepository(
+            $this->presetRepository,
+            $this->sessionService,
+            new OptionCollectionMapper()
+        );
+    }
+
+    /**
+     * @param OptionCollection   $expected
+     * @param Session            $sessionData
+     * @param TestCategoryPreset ...$availableToolPresets
+     *
+     * @dataProvider dataProvider
+     */
+    public function testFindAll(
+        OptionCollection $expected,
+        Session $sessionData,
+        TestCategoryPreset ...$availableToolPresets
+    ): void {
+        $this->presetRepository
+            ->method('findPresetGroupOrFail')
+            ->willReturn(['presets' => $availableToolPresets]);
+
+        $this->sessionService
+            ->expects(static::once())
+            ->method('getCurrentSession')
+            ->willReturn($sessionData);
+
+        $this->assertEquals($expected, $this->sut->findAll());
+    }
+
+    public function dataProvider(): array
+    {
+        return [
+            'Matching options'         => [
+                new OptionCollection(
+                    new Option('opt_1', true),
+                    new Option('opt_2', false)
+                ),
+                $this->createLtiSession(
+                    [
+                        'opt_1' => true,
+                        'opt_2' => false,
+                    ]
+                ),
+                $this->createPreset('opt_1'),
+                $this->createPreset('opt_2'),
+                $this->createPreset('opt_3'),
+            ],
+            'Extra options'            => [
+                new OptionCollection(
+                    new Option('opt_1', true),
+                    new Option('opt_2', false)
+                ),
+                $this->createLtiSession(
+                    [
+                        'opt_1' => true,
+                        'opt_2' => false,
+                        'opt_4' => false,
+                    ]
+                ),
+                $this->createPreset('opt_1'),
+                $this->createPreset('opt_2'),
+                $this->createPreset('opt_3'),
+            ],
+            'Empty unfiltered options' => [
+                new OptionCollection(),
+                $this->createLtiSession([]),
+                $this->createPreset('opt_1'),
+                $this->createPreset('opt_2'),
+                $this->createPreset('opt_3'),
+            ],
+            'Non-LTI session' => [
+                new OptionCollection(),
+                $this->createMock(Session::class),
+                $this->createPreset('opt_1'),
+                $this->createPreset('opt_2'),
+                $this->createPreset('opt_3'),
+            ],
+        ];
+    }
+
+    private function createPreset(string $id): TestCategoryPreset
+    {
+        /** @noinspection PhpUnhandledExceptionInspection */
+        return new TestCategoryPreset($id, 'test', 'test', []);
+    }
+
+    private function createLtiSession(array $toolConfiguration): TaoLtiSession
+    {
+        $session    = $this->createMock(TaoLtiSession::class);
+        $launchData = $this->createMock(LtiLaunchData::class);
+
+        $session
+            ->expects(static::once())
+            ->method('getLaunchData')
+            ->willReturn($launchData);
+
+        $hasData = !empty($toolConfiguration);
+
+        $launchData
+            ->expects(static::once())
+            ->method('hasVariable')
+            ->with('custom_x_tao_tools')
+            ->willReturn($hasData);
+
+        $launchData
+            ->expects($hasData ? static::once() : static::never())
+            ->method('getVariable')
+            ->with('custom_x_tao_tools')
+            ->willReturn(json_encode($toolConfiguration));
+
+        return $session;
+    }
+}


### PR DESCRIPTION
BSA-81 feat: implement `OverriddenLtiToolsRepository` allowing to ovrride accessibility tools configuration during an LTI delivery execution
BSA-81 feat: override the no-op `OverriddenOptionsRepository` upon the extension's installation and update
BSA-85 chore(dependency): add explicit dependency on `taoQtiTest`
BSA-85 chore(version): bump a minor one

Requires [`taoQtiTest` #1744](https://github.com/oat-sa/extension-tao-testqti/pull/1744).

To use the feature:
1. Set up an LTI delivery
2. Provide a custom `x_tao_tools` LTI-launch parameter in the following format: `{"<tool_id>":<bool>}`, e.g. `{"magnifier": true, "zoom": false}` to force the magnifier tool usage and restrict the zoom one.