### PR TITLE
Feature/tca 443/lti redirect when max attempts limit reached

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '10.5.0',
+    'version' => '10.5.1',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'generis' => '>=12.15.0',

--- a/model/LtiAssignment.php
+++ b/model/LtiAssignment.php
@@ -29,6 +29,7 @@ use oat\oatbox\session\SessionService;
 use oat\taoDelivery\model\AttemptServiceInterface;
 use oat\taoDeliveryRdf\model\DeliveryContainerService;
 use oat\oatbox\user\User;
+use oat\taoLti\models\classes\LtiClientException;
 use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
 use oat\taoLti\models\classes\TaoLtiSession;
@@ -87,7 +88,7 @@ class LtiAssignment extends ConfigurableService
             if ($launchData->hasVariable(self::LTI_MAX_ATTEMPTS_VARIABLE)) {
                 $val = $launchData->getVariable(self::LTI_MAX_ATTEMPTS_VARIABLE);
                 if (!is_numeric($val)) {
-                    throw new LtiException(
+                    throw new LtiClientException(
                         __('"max_attempts" variable must me numeric.'),
                         LtiErrorMessage::ERROR_INVALID_PARAMETER
                     );
@@ -102,7 +103,7 @@ class LtiAssignment extends ConfigurableService
 
         if (($maxExec != 0) && ($usedTokens >= $maxExec)) {
             $this->logDebug("Attempt to start the compiled delivery " . $delivery->getUri() . " without tokens");
-            throw new LtiException(
+            throw new LtiClientException(
                 __('Attempts limit has been reached.'),
                 LtiErrorMessage::ERROR_LAUNCH_FORBIDDEN
             );

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -311,6 +311,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(LTIDeliveryToolFactory::SERVICE_ID, new LTIDeliveryToolFactory());
             $this->setVersion('9.4.0');
         }
-        $this->skip('9.4.0', '10.5.0');
+        $this->skip('9.4.0', '10.5.1');
     }
 }

--- a/test/unit/model/LtiAssignmentTest.php
+++ b/test/unit/model/LtiAssignmentTest.php
@@ -20,14 +20,14 @@
 
 namespace oat\ltiDeliveryProvider\test\unit\model\requestLog\rds;
 
-use oat\generis\model\data\Model;
+use core_kernel_classes_Literal;
 use oat\generis\model\data\Ontology;
 use oat\generis\test\TestCase;
 use oat\ltiDeliveryProvider\model\LtiAssignment;
 use oat\oatbox\session\SessionService;
 use oat\oatbox\user\User;
 use oat\taoDelivery\model\AttemptServiceInterface;
-use oat\taoLti\models\classes\LtiException;
+use oat\taoLti\models\classes\LtiClientException;
 use oat\taoLti\models\classes\LtiLaunchData;
 use oat\taoLti\models\classes\TaoLtiSession;
 use Psr\Log\LoggerInterface;
@@ -90,6 +90,7 @@ class LtiAssignmentTest extends TestCase
             ->willReturn($this->deliveryMock);
         $modelMock->expects($this->once())
             ->method('getProperty')
+            ->with('http://www.tao.lu/Ontologies/TAODelivery.rdf#Maxexec')
             ->willReturn(new \core_kernel_classes_Property('PROP'));
 
         $this->object = new LtiAssignment([]);
@@ -103,7 +104,7 @@ class LtiAssignmentTest extends TestCase
      */
     public function testIsDeliveryExecutionAllowedNotNumericLtiMaxAttemptsLtiParameter()
     {
-        $this->expectException(LtiException::class);
+        $this->expectException(LtiClientException::class);
 
         $this->sessionServiceMock->expects($this->once())
             ->method('getCurrentSession')
@@ -164,11 +165,11 @@ class LtiAssignmentTest extends TestCase
      */
     public function testIsDeliveryExecutionAllowedAttemptsLimitReached()
     {
-        $this->expectException(LtiException::class);
+        $this->expectException(LtiClientException::class);
 
         $this->deliveryMock->expects($this->once())
             ->method('getOnePropertyValue')
-            ->willReturn(new \core_kernel_classes_Literal('2'));
+            ->willReturn(new core_kernel_classes_Literal('2'));
 
         $userTokens = [1, 2, 3, 4]; // Amount must be higher than max allowed executions.
         $this->attemptServiceMock->expects($this->once())
@@ -185,7 +186,7 @@ class LtiAssignmentTest extends TestCase
     {
         $this->deliveryMock->expects($this->once())
             ->method('getOnePropertyValue')
-            ->willReturn(new \core_kernel_classes_Literal('2'));
+            ->willReturn(new core_kernel_classes_Literal('2'));
 
         $userTokens = [1]; // Amount must be higher than max allowed executions.
         $this->attemptServiceMock->expects($this->once())


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/TCA-443

Problem: When `custom_max_attempts` LTI parameter is present and maximum attempts limit is reached TAO should redirect back to LTI return url instead of shoving an error page.

How to test:
- launch LTI delivery execution with `custom_max_attempts=1`
- complete delivery execution and try to launch it again