### PR TITLE
Feature/tca 651/login queue ce

### DIFF
--- a/install/RegisterLaunchAction.php
+++ b/install/RegisterLaunchAction.php
@@ -21,7 +21,7 @@
 
 namespace oat\ltiDeliveryProvider\install;
 
-use oat\ltiDeliveryProvider\model\metrics\activeLimitRestriction;
+use oat\ltiDeliveryProvider\model\metrics\ActiveLimitRestriction;
 use oat\ltiDeliveryProvider\model\metrics\implementation\activeExecutionsMetrics;
 use oat\oatbox\extension\AbstractAction;
 use oat\tao\model\actionQueue\ActionQueue;
@@ -52,7 +52,7 @@ class RegisterLaunchAction extends AbstractAction
         $actions = $actionQueue->getOption(ActionQueue::OPTION_ACTIONS);
         $actions[GetActiveDeliveryExecution::class] = [
                 'restrictions' => [
-                    activeLimitRestriction::class => 0
+                    ActiveLimitRestriction::class => 0
                 ],
                 ActionQueue::ACTION_PARAM_TTL => 3600, //one hour
         ];

--- a/manifest.php
+++ b/manifest.php
@@ -29,11 +29,11 @@ return [
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '11.1.0',
+    'version' => '11.2.0',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'generis' => '>=12.15.0',
-        'tao' => '>=39.4.0',
+        'tao' => '>=44.0.0',
         'taoDeliveryRdf' => '>=6.0.0',
         'taoLti' => '>=10.5.0',
         'taoResultServer' => '>=7.0.0',

--- a/model/metrics/ActiveLimitRestriction.php
+++ b/model/metrics/ActiveLimitRestriction.php
@@ -23,21 +23,21 @@
 namespace oat\ltiDeliveryProvider\model\metrics;
 
 use oat\ltiDeliveryProvider\model\metrics\implementation\activeExecutionsMetrics;
-use oat\tao\model\actionQueue\restriction\basicRestriction;
+use oat\oatbox\service\exception\InvalidServiceManagerException;
+use oat\tao\model\actionQueue\restriction\BasicRestriction;
 use oat\tao\model\metrics\MetricsService;
 
-class activeLimitRestriction extends basicRestriction
+class ActiveLimitRestriction extends BasicRestriction
 {
 
     const METRIC = activeExecutionsMetrics::class;
 
     /**
      * @param $value
-     * @return boolean
-     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
-     * @throws \oat\tao\model\metadata\exception\InconsistencyConfigException
+     * @return bool
+     * @throws InvalidServiceManagerException
      */
-    public function doesComplies($value)
+    public function doesComply($value)
     {
         if ($value === 0) {
             return true;

--- a/model/metrics/ActiveLimitRestriction.php
+++ b/model/metrics/ActiveLimitRestriction.php
@@ -35,14 +35,13 @@ class ActiveLimitRestriction extends BasicRestriction
     /**
      * @param $value
      * @return bool
-     * @throws InvalidServiceManagerException
      */
     public function doesComply($value)
     {
         if ($value === 0) {
             return true;
         }
-        $metric = $this->getServiceManager()->get(MetricsService::class)->getOneMetric(self::METRIC);
+        $metric = $this->getServiceLocator()->get(MetricsService::class)->getOneMetric(self::METRIC);
         return $value > $metric->collect();
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -32,7 +32,7 @@ use oat\ltiDeliveryProvider\model\LTIDeliveryToolFactory;
 use oat\ltiDeliveryProvider\model\LtiLaunchDataService;
 use oat\ltiDeliveryProvider\model\LtiOutcomeService;
 use oat\ltiDeliveryProvider\model\LtiResultAliasStorage;
-use oat\ltiDeliveryProvider\model\metrics\activeLimitRestriction;
+use oat\ltiDeliveryProvider\model\metrics\ActiveLimitRestriction;
 use oat\ltiDeliveryProvider\model\metrics\implementation\activeExecutionsMetrics;
 use oat\ltiDeliveryProvider\model\navigation\DefaultMessageFactory;
 use oat\ltiDeliveryProvider\model\navigation\LtiNavigationService;
@@ -233,7 +233,7 @@ class Updater extends \common_ext_ExtensionUpdater
             foreach ($actions as $action => $params) {
                 if (array_key_exists('limit', $params)) {
                     $limit = $params['limit'];
-                    $params['restrictions'][activeLimitRestriction::class] = $limit;
+                    $params['restrictions'][ActiveLimitRestriction::class] = $limit;
                     unset($params['limit']);
                     $actions[$action] = $params;
                 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -347,10 +347,10 @@ class Updater extends \common_ext_ExtensionUpdater
                 if (isset($options[ActionQueue::OPTION_ACTIONS][GetActiveDeliveryExecution::class]['restrictions'])) {
                     $restrictions = $options[ActionQueue::OPTION_ACTIONS][GetActiveDeliveryExecution::class]['restrictions'];
 
-                    $deprecatedClassname = 'oat\\ltiDeliveryProvider\\model\\metrics\\activeLimitRestriction';
-                    if (isset($restrictions[$deprecatedClassname])) {
-                        $restrictionOptions = $restrictions[$deprecatedClassname];
-                        unset($restrictions[$deprecatedClassname]);
+                    $renamedClassname = 'oat\\ltiDeliveryProvider\\model\\metrics\\activeLimitRestriction';
+                    if (isset($restrictions[$renamedClassname])) {
+                        $restrictionOptions = $restrictions[$renamedClassname];
+                        unset($restrictions[$renamedClassname]);
                         $restrictions[ActiveLimitRestriction::class] = $restrictionOptions;
                     }
 


### PR DESCRIPTION
Changes reflecting renamed class in tao-core.
 
Related to : https://oat-sa.atlassian.net/browse/TCA-651
  
#### How to test
 
- Configure `oat\tao\model\actionQueue\ActionQueue::SERVICE_ID` with `oat\ltiDeliveryProvider\model\actions\GetActiveDeliveryExecution` action, which would have the old `oat\ltiDeliveryProvider\model\metrics\activeLimitRestriction`. f.e.:

```
return new oat\tao\model\actionQueue\implementation\InstantActionQueue(array(
    'persistence' => 'redis',
    'actions' => array(
        'oat\\ltiDeliveryProvider\\model\\actions\\GetActiveDeliveryExecution' => array(
            'ttl' => 60,
            'restrictions' => array(
                'oat\\ltiDeliveryProvider\\model\\metrics\\activeLimitRestriction' => 0
            )
        )
    )
));
```
- run `php ./tao/scripts/taoUpdate.php`, verify that the renamed service is replaced with `oat\ltiDeliveryProvider\model\metrics\ActiveLimitRestriction`.
 
#### Dependencies
 
Requires :
 - [x] https://github.com/oat-sa/tao-core/pull/2553
 - [x] https://github.com/oat-sa/extension-tao-delivery/pull/478
 
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-act/pull/1396