### PR TITLE
Fix BSA-225 apply SameSite None for 3rd party domain LTI launch session cookie

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -15,12 +15,21 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
 use oat\ltiDeliveryProvider\controller\DeliveryRunner;
 use oat\ltiDeliveryProvider\controller\DeliveryTool;
 use oat\ltiDeliveryProvider\controller\LinkConfiguration;
+use oat\ltiDeliveryProvider\install\InstallAssignmentService;
+use oat\ltiDeliveryProvider\install\InstallDeliveryContainerService;
+use oat\ltiDeliveryProvider\install\RegisterLaunchAction;
+use oat\ltiDeliveryProvider\scripts\install\RegisterLtiAttemptService;
+use oat\ltiDeliveryProvider\scripts\install\RegisterLtiResultAliasStorage;
+use oat\ltiDeliveryProvider\scripts\install\RegisterMetrics;
+use oat\ltiDeliveryProvider\scripts\install\RegisterOverriddenLtiToolRepository;
+use oat\ltiDeliveryProvider\scripts\install\RegisterServices;
+use oat\ltiDeliveryProvider\scripts\update\Updater;
 use oat\tao\model\user\TaoRoles;
 use oat\taoLti\models\classes\LtiRoles;
 
@@ -29,11 +38,11 @@ return [
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '11.3.1',
+    'version' => '11.4.0',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'generis' => '>=12.15.0',
-        'tao' => '>=44.0.0',
+        'tao' => '>=45.7.0',
         'taoDeliveryRdf' => '>=6.0.0',
         'taoLti' => '>=10.5.0',
         'taoResultServer' => '>=7.0.0',
@@ -47,14 +56,14 @@ return [
      ],
     'install' => [
         'php' => [
-            \oat\ltiDeliveryProvider\install\InstallAssignmentService::class,
-            \oat\ltiDeliveryProvider\scripts\install\RegisterLtiResultAliasStorage::class,
-            \oat\ltiDeliveryProvider\scripts\install\RegisterServices::class,
-            \oat\ltiDeliveryProvider\install\RegisterLaunchAction::class,
-            \oat\ltiDeliveryProvider\install\InstallDeliveryContainerService::class,
-            \oat\ltiDeliveryProvider\scripts\install\RegisterLtiAttemptService::class,
-            \oat\ltiDeliveryProvider\scripts\install\RegisterMetrics::class,
-            \oat\ltiDeliveryProvider\scripts\install\RegisterOverriddenLtiToolRepository::class,
+            InstallAssignmentService::class,
+            RegisterLtiResultAliasStorage::class,
+            RegisterServices::class,
+            RegisterLaunchAction::class,
+            InstallDeliveryContainerService::class,
+            RegisterLtiAttemptService::class,
+            RegisterMetrics::class,
+            RegisterOverriddenLtiToolRepository::class,
         ],
         'rdf' => [
             __DIR__ . '/install/ontology/deliverytool.rdf'
@@ -63,7 +72,7 @@ return [
     'routes' => [
         '/ltiDeliveryProvider' => 'oat\\ltiDeliveryProvider\\controller'
     ],
-    'update' => 'oat\\ltiDeliveryProvider\\scripts\\update\\Updater',
+    'update' => Updater::class,
     'managementRole' => 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LtiDeliveryProviderManagerRole',
     'acl' => [
         ['grant', 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LtiDeliveryProviderManagerRole', ['ext' => 'ltiDeliveryProvider']],

--- a/manifest.php
+++ b/manifest.php
@@ -29,6 +29,7 @@ use oat\ltiDeliveryProvider\scripts\install\RegisterLtiResultAliasStorage;
 use oat\ltiDeliveryProvider\scripts\install\RegisterMetrics;
 use oat\ltiDeliveryProvider\scripts\install\RegisterOverriddenLtiToolRepository;
 use oat\ltiDeliveryProvider\scripts\install\RegisterServices;
+use oat\ltiDeliveryProvider\scripts\install\RegisterSessionCookieAttributesFactory;
 use oat\ltiDeliveryProvider\scripts\update\Updater;
 use oat\tao\model\user\TaoRoles;
 use oat\taoLti\models\classes\LtiRoles;
@@ -64,6 +65,7 @@ return [
             RegisterLtiAttemptService::class,
             RegisterMetrics::class,
             RegisterOverriddenLtiToolRepository::class,
+            RegisterSessionCookieAttributesFactory::class
         ],
         'rdf' => [
             __DIR__ . '/install/ontology/deliverytool.rdf'

--- a/migrations/Version202008201411081874_ltiDeliveryProvider.php
+++ b/migrations/Version202008201411081874_ltiDeliveryProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\ltiDeliveryProvider\model\session\DataAccess\Factory\SessionCookieAttributesFactory;
+use oat\ltiDeliveryProvider\scripts\install\RegisterSessionCookieAttributesFactory;
+use oat\tao\scripts\install\RegisterSessionCookieService;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202008201411081874_ltiDeliveryProvider extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Register ' . SessionCookieAttributesFactory::class;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addReport(
+            $this->propagate(
+                new RegisterSessionCookieAttributesFactory()
+            )()
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addReport(
+            $this->propagate(
+                new RegisterSessionCookieService()
+            )()
+        );
+
+        $this->getServiceManager()->unregister(SessionCookieAttributesFactory::SERVICE_ID);
+    }
+}

--- a/model/session/DataAccess/Factory/SessionCookieAttributesFactory.php
+++ b/model/session/DataAccess/Factory/SessionCookieAttributesFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\model\session\DataAccess\Factory;
+
+use common_http_Request as Request;
+use oat\tao\model\security\Business\Contract\SecuritySettingsRepositoryInterface;
+use oat\tao\model\service\InjectionAwareService;
+use oat\tao\model\session\Business\Contract\SessionCookieAttributesFactoryInterface;
+use oat\tao\model\session\Business\Domain\SessionCookieAttribute;
+use oat\tao\model\session\Business\Domain\SessionCookieAttributeCollection;
+use oat\taoLti\models\classes\LtiLaunchData;
+
+class SessionCookieAttributesFactory extends InjectionAwareService implements SessionCookieAttributesFactoryInterface
+{
+    public const SERVICE_ID = 'taoLti/SessionCookieAttributesFactory';
+
+    /** @var SessionCookieAttributesFactoryInterface */
+    private $sessionCookieAttributesFactory;
+    /** @var SecuritySettingsRepositoryInterface */
+    private $securitySettingsRepository;
+
+    public function __construct(
+        SessionCookieAttributesFactoryInterface $sessionCookieAttributesFactory,
+        SecuritySettingsRepositoryInterface $securitySettingsRepository
+    ) {
+        parent::__construct();
+
+        $this->sessionCookieAttributesFactory = $sessionCookieAttributesFactory;
+        $this->securitySettingsRepository     = $securitySettingsRepository;
+    }
+
+    public function create(): SessionCookieAttributeCollection
+    {
+        $attributes = $this->sessionCookieAttributesFactory->create();
+
+        $ltiLaunchData = LtiLaunchData::fromRequest(Request::currentRequest());
+
+        if (!$ltiLaunchData->hasVariable(LtiLaunchData::LTI_VERSION)) {
+            return $attributes;
+        }
+
+        $whitelistedSources = $this->securitySettingsRepository->findAll()->findContentSecurityPolicy()->getValue();
+
+        if (!in_array($whitelistedSources, ['*', 'list'], true)) {
+            return $attributes;
+        }
+
+        return $attributes
+            ->add(new SessionCookieAttribute('samesite', 'none'));
+    }
+}

--- a/scripts/install/RegisterSessionCookieAttributesFactory.php
+++ b/scripts/install/RegisterSessionCookieAttributesFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\scripts\install;
+
+use common_report_Report as Report;
+use oat\ltiDeliveryProvider\model\session\DataAccess\Factory\SessionCookieAttributesFactory;
+use oat\oatbox\extension\InstallAction;
+use oat\tao\model\security\Business\Contract\SecuritySettingsRepositoryInterface;
+use oat\tao\model\session\Business\Service\SessionCookieService;
+use oat\tao\model\session\DataAccess\Factory\SessionCookieAttributesFactory as BaseSessionCookieAttributesFactory;
+
+class RegisterSessionCookieAttributesFactory extends InstallAction
+{
+    public function __invoke($params = [])
+    {
+        /** @var BaseSessionCookieAttributesFactory $basSessionCookieAttributesFactory */
+        $basSessionCookieAttributesFactory = $this->getServiceLocator()->get(BaseSessionCookieAttributesFactory::class);
+        /** @var SecuritySettingsRepositoryInterface $securitySettingsRepository */
+        $securitySettingsRepository = $this->getServiceLocator()->get(SecuritySettingsRepositoryInterface::class);
+
+        $sessionCookieAttributesFactory = new SessionCookieAttributesFactory(
+            $basSessionCookieAttributesFactory,
+            $securitySettingsRepository
+        );
+        $this->getServiceManager()->register(
+            SessionCookieAttributesFactory::SERVICE_ID,
+            $sessionCookieAttributesFactory
+        );
+
+        $this->getServiceManager()->register(
+            SessionCookieService::SERVICE_ID,
+            new SessionCookieService($sessionCookieAttributesFactory)
+        );
+
+        return Report::createSuccess(SessionCookieAttributesFactory::class . ' registered');
+    }
+}


### PR DESCRIPTION
- [BSA-225](https://oat-sa.atlassian.net/browse/BSA-225) chore(dependency): increase a `tao` dependency to `45.7.0`, introducing `SessionCookieService`
- [BSA-225](https://oat-sa.atlassian.net/browse/BSA-225) chore(version): bump a minor one
- [BSA-225](https://oat-sa.atlassian.net/browse/BSA-225) feat: introduce `SessionCookieAttributesFactory`, setting a `samesite=none` cookie argument in case of an LTI delivery launch when a 3rd party domain is allowed to be used by security settings, allowing to launch an LTI delivery within an iframe

⚠️ Depends on `tao` #2647(https://github.com/oat-sa/tao-core/pull/2647).