### PR TITLE
Fix/tao 9835/fix replace result namespace

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return [
         'generis' => '>=12.15.0',
         'tao' => '>=45.7.0',
         'taoDeliveryRdf' => '>=6.0.0',
-        'taoLti' => '>=10.5.0',
+        'taoLti' => '>=11.12.0',
         'taoResultServer' => '>=7.0.0',
         'taoDelivery' => '>=11.0.0',
         'taoOutcomeUi' => '>=7.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return [
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '11.4.0',
+    'version' => '11.4.1',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'generis' => '>=12.15.0',

--- a/model/tasks/SendLtiOutcomeTask.php
+++ b/model/tasks/SendLtiOutcomeTask.php
@@ -91,7 +91,7 @@ class SendLtiOutcomeTask extends AbstractAction
         $deliveryResultAlias = $resultAliasService->getResultAlias($deliveryResultIdentifier);
         $deliveryResultIdentifier = empty($deliveryResultAlias) ? $deliveryResultIdentifier : current($deliveryResultAlias);
 
-        $message = $this->getLtiOutcomeXmlFactory()->build($deliveryResultIdentifier, $grade);
+        $message = $this->getLtiOutcomeXmlFactory()->build($deliveryResultIdentifier, $grade, uniqid('', true));
 
         $credentialResource = LtiService::singleton()->getCredential($consumerKey);
         $credentials = new \tao_models_classes_oauth_Credentials($credentialResource);

--- a/model/tasks/SendLtiOutcomeTask.php
+++ b/model/tasks/SendLtiOutcomeTask.php
@@ -15,10 +15,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2014-2020 (original work) Open Assessment Technologies SA;
  *
  */
+
+declare(strict_types=1);
 
 namespace oat\ltiDeliveryProvider\model\tasks;
 
@@ -118,12 +119,12 @@ class SendLtiOutcomeTask extends AbstractAction
         return true;
     }
 
-    private function buildXMLMessage($sourcedId, $grade)
+    private function buildXMLMessage($sourcedId, $grade): string
     {
         $language = 'en-us';
         $operation = 'replaceResultRequest';
         $body = '<?xml version = "1.0" encoding = "UTF-8"?>
-                <imsx_POXEnvelopeRequest xmlns = "http://www.imsglobal.org/lis/oms1p0/pox">
+                <imsx_POXEnvelopeRequest xmlns = "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
                     <imsx_POXHeader>
                         <imsx_POXRequestHeaderInfo>
                             <imsx_version>V1.0</imsx_version>

--- a/test/unit/model/LtiDeliveryFactoryTest.php
+++ b/test/unit/model/LtiDeliveryFactoryTest.php
@@ -15,11 +15,13 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2019-2020 (original work) Open Assessment Technologies SA;
  *
  */
 
-namespace oat\ltiDeliveryProvider\tests\model;
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\test\model;
 
 use oat\generis\test\TestCase;
 use oat\ltiDeliveryProvider\model\LtiDeliveryFactory;
@@ -28,7 +30,7 @@ use oat\ltiDeliveryProvider\model\LTIDeliveryToolFactory;
 
 class LtiDeliveryFactoryTest extends TestCase
 {
-    public function testCreateFromLtiSession()
+    public function testCreateFromLtiSession(): void
     {
         $tool = $this->getMockBuilder(LTIDeliveryTool::class)->disableOriginalConstructor()->getMock();
         $tool->expects($this->once())->method('getDeliveryFromLink')->willReturn(true);

--- a/test/unit/model/LtiLaunchDataServiceTest.php
+++ b/test/unit/model/LtiLaunchDataServiceTest.php
@@ -15,20 +15,23 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2019-2020 (original work) Open Assessment Technologies SA;
  *
  */
 
-namespace oat\ltiDeliveryProvider\tests\model;
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\test\model;
 
 use oat\generis\test\TestCase;
 use oat\ltiDeliveryProvider\model\LtiDeliveryFactory;
 use oat\ltiDeliveryProvider\model\LtiLaunchDataService;
 use oat\taoLti\models\classes\LtiLaunchData;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class LtiLaunchDataServiceTest extends TestCase
 {
-    public function testFindDeliveryFromLaunchData()
+    public function testFindDeliveryFromLaunchData(): void
     {
         $service = $this->getLtiLaunchDataService([
             LtiDeliveryFactory::SERVICE_ID => $this->getLtiDeliveryFactoryMock()
@@ -41,7 +44,7 @@ class LtiLaunchDataServiceTest extends TestCase
         $this->assertTrue($delivery);
     }
 
-    public function testFindDeliveryExecutionFromLaunchData()
+    public function testFindDeliveryExecutionFromLaunchData(): void
     {
         $service = $this->getLtiLaunchDataService([
             LtiDeliveryFactory::SERVICE_ID => $this->getLtiDeliveryFactoryMock()
@@ -52,7 +55,7 @@ class LtiLaunchDataServiceTest extends TestCase
         $this->assertTrue($service->findDeliveryExecutionFromLaunchData($data));
     }
 
-    private function getLtiDeliveryFactoryMock()
+    private function getLtiDeliveryFactoryMock(): MockObject
     {
         $factory = $this->getMockBuilder(LtiDeliveryFactory::class)->getMock();
         $factory->method('create')->willReturn(true);
@@ -65,7 +68,7 @@ class LtiLaunchDataServiceTest extends TestCase
      *
      * @return LtiLaunchDataService
      */
-    private function getLtiLaunchDataService(array $services)
+    private function getLtiLaunchDataService(array $services): LtiLaunchDataService
     {
         $serviceLocatorMock = $this->getServiceLocatorMock($services);
 


### PR DESCRIPTION
In order to follow ltiv1p1 spec, replaceResult xml must be adapted to follow specifications.

LTI specificications: https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-26
Ticket: https://oat-sa.atlassian.net/browse/TAO-9835

No test possible because of usage of singleton...