### PR TITLE
INV-301 fix the default language

### DIFF
--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -254,6 +254,6 @@ class DeliveryTool extends ToolModule
             ->get(common_ext_ExtensionsManager::SERVICE_ID)
             ->getExtensionById('ltiDeliveryProvider');
 
-        tao_helpers_I18n::init($extension, DEFAULT_LANG);
+        tao_helpers_I18n::init($extension, DEFAULT_ANONYMOUS_INTERFACE_LANG);
     }
 }


### PR DESCRIPTION
As we never change the default language, for login queue we need to use the DEFAULT_ANONYMOUS_INTERFACE_LANG instead.