### PR TITLE
Redirect user to the return url instead of showing "You have already taken this test." page.

### DIFF
--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -194,6 +194,11 @@ class DeliveryTool extends ToolModule
         /** @var LtiAssignment $assignmentService */
         $assignmentService = $this->getServiceLocator()->get(LtiAssignment::SERVICE_ID);
         if ($assignmentService->isDeliveryExecutionAllowed($delivery->getUri(), $user)) {
+
+            if (defined(FORCE_REDIRECT_TO_RETURNURL) &&  FORCE_REDIRECT_TO_RETURNURL === true) {
+                return $user->getLaunchData()->getVariable('launch_presentation_return_url');
+            }
+
             return _url('ltiOverview', 'DeliveryRunner', null, ['delivery' => $delivery->getUri()]);
         } else {
             throw new LtiException(

--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -68,7 +68,7 @@ class DeliveryTool extends ToolModule
      * screen to be shown skip directly to the return url
      * @var string
      */
-    const FORCE_REDIRECT_TO_RETURNURL = 'custom_force_redirect_to_return_url';
+    const FORCE_REDIRECT_TO_RETURN_URL = 'custom_force_redirect_to_return_url';
 
     /**
      * Setting this parameter to a string will show this string as the title of the thankyou
@@ -204,7 +204,7 @@ class DeliveryTool extends ToolModule
         $assignmentService = $this->getServiceLocator()->get(LtiAssignment::SERVICE_ID);
         if ($assignmentService->isDeliveryExecutionAllowed($delivery->getUri(), $user)) {
 
-            if ($user->getLaunchData()->hasVariable(self::FORCE_REDIRECT_TO_RETURNURL)) {
+            if ($user->getLaunchData()->hasVariable(self::FORCE_REDIRECT_TO_RETURN_URL)) {
                 return $user->getLaunchData()->getVariable(LtiLaunchData::LAUNCH_PRESENTATION_RETURN_URL);
             }
 

--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -45,6 +45,7 @@ use oat\taoLti\models\classes\LtiService;
 use oat\taoLti\models\classes\LtiVariableMissingException;
 use oat\taoQtiTest\models\QtiTestExtractionFailedException;
 use tao_helpers_Uri;
+use oat\ltiDeliveryProvider\model\navigation\LtiNavigationService;
 
 class DeliveryTool extends ToolModule
 {
@@ -68,7 +69,7 @@ class DeliveryTool extends ToolModule
      * screen to be shown skip directly to the return url
      * @var string
      */
-    const FORCE_REDIRECT_TO_RETURN_URL = 'custom_force_redirect_to_return_url';
+    const PARAM_FORCE_REDIRECT_TO_RETURN_URL = 'custom_force_redirect_to_return_url';
 
     /**
      * Setting this parameter to a string will show this string as the title of the thankyou
@@ -211,16 +212,14 @@ class DeliveryTool extends ToolModule
             );
         }
 
-        if ($user->getLaunchData()->hasVariable(self::FORCE_REDIRECT_TO_RETURN_URL)) {
+        if ($user->getLaunchData()->hasVariable(self::PARAM_FORCE_REDIRECT_TO_RETURN_URL)) {
             $executionService = $this->getServiceLocator()->get(LtiDeliveryExecutionService::SERVICE_ID);
             $executions = $executionService->getLinkedDeliveryExecutions($delivery, $currentSession->getLtiLinkResource(), $user->getIdentifier());
             $lastDE = end($executions);
-            $url = _url(
-                'ltiReturn',
-                'DeliveryRunner',
-                'ltiDeliveryProvider',
-                ['deliveryExecution' => $lastDE->getIdentifier()]
-            );
+            $dataLaunch = LtiService::singleton()->getLtiSession()->getLaunchData();
+            /** @var LtiNavigationService $s */
+            $ltiNavigationService = $this->getServiceLocator()->get(LtiNavigationService::SERVICE_ID);
+            $url = $ltiNavigationService->getReturnUrl($dataLaunch, $lastDE);
         } else {
             $url = _url(
                 'ltiOverview',

--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -25,6 +25,7 @@ use common_Logger;
 use common_session_SessionManager;
 use core_kernel_classes_Resource;
 
+use oat\taoLti\models\classes\LtiLaunchData;
 use tao_helpers_I18n;
 use tao_models_classes_LanguageService;
 use function GuzzleHttp\Psr7\stream_for;
@@ -203,10 +204,8 @@ class DeliveryTool extends ToolModule
         $assignmentService = $this->getServiceLocator()->get(LtiAssignment::SERVICE_ID);
         if ($assignmentService->isDeliveryExecutionAllowed($delivery->getUri(), $user)) {
 
-            $launchDataService = $this->getServiceLocator()->get(LtiLaunchDataService::SERVICE_ID);
-
-            if ($launchDataService->hasVariable(self::FORCE_REDIRECT_TO_RETURNURL)) {
-                    return $user->getLaunchData()->getVariable('launch_presentation_return_url');
+            if ($user->getLaunchData()->hasVariable(self::FORCE_REDIRECT_TO_RETURNURL)) {
+                    return $user->getLaunchData()->getVariable(LtiLaunchData::LAUNCH_PRESENTATION_RETURN_URL);
             }
 
             return _url('ltiOverview', 'DeliveryRunner', null, ['delivery' => $delivery->getUri()]);

--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -205,7 +205,7 @@ class DeliveryTool extends ToolModule
         if ($assignmentService->isDeliveryExecutionAllowed($delivery->getUri(), $user)) {
 
             if ($user->getLaunchData()->hasVariable(self::FORCE_REDIRECT_TO_RETURNURL)) {
-                    return $user->getLaunchData()->getVariable(LtiLaunchData::LAUNCH_PRESENTATION_RETURN_URL);
+                return $user->getLaunchData()->getVariable(LtiLaunchData::LAUNCH_PRESENTATION_RETURN_URL);
             }
 
             return _url('ltiOverview', 'DeliveryRunner', null, ['delivery' => $delivery->getUri()]);

--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -69,7 +69,7 @@ class DeliveryTool extends ToolModule
      * screen to be shown skip directly to the return url
      * @var string
      */
-    const PARAM_FORCE_REDIRECT_TO_RETURN_URL = 'custom_force_redirect_to_return_url';
+    const PARAM_SKIP_OVERVIEW = 'custom_skip_overview';
 
     /**
      * Setting this parameter to a string will show this string as the title of the thankyou
@@ -212,14 +212,13 @@ class DeliveryTool extends ToolModule
             );
         }
 
-        if ($user->getLaunchData()->hasVariable(self::PARAM_FORCE_REDIRECT_TO_RETURN_URL)) {
+        if ($user->getLaunchData()->hasVariable(self::PARAM_SKIP_OVERVIEW)) {
             $executionService = $this->getServiceLocator()->get(LtiDeliveryExecutionService::SERVICE_ID);
             $executions = $executionService->getLinkedDeliveryExecutions($delivery, $currentSession->getLtiLinkResource(), $user->getIdentifier());
             $lastDE = end($executions);
-            $dataLaunch = LtiService::singleton()->getLtiSession()->getLaunchData();
-            /** @var LtiNavigationService $s */
+            /** @var LtiNavigationService $ltiNavigationService */
             $ltiNavigationService = $this->getServiceLocator()->get(LtiNavigationService::SERVICE_ID);
-            $url = $ltiNavigationService->getReturnUrl($dataLaunch, $lastDE);
+            $url = $ltiNavigationService->getReturnUrl($user->getLaunchData(), $lastDE);
         } else {
             $url = _url(
                 'ltiOverview',

--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -61,6 +61,14 @@ class DeliveryTool extends ToolModule
      * @var string
      */
     const PARAM_SKIP_THANKYOU = 'custom_skip_thankyou';
+
+    /**
+     * Setting this parameter to 'true' will prevent the 'You have already taken this test'
+     * screen to be shown skip directly to the return url
+     * @var string
+     */
+    const FORCE_REDIRECT_TO_RETURNURL = 'custom_force_redirect_to_return_url';
+
     /**
      * Setting this parameter to a string will show this string as the title of the thankyou
      * page. (no effect if PARAM_SKIP_THANKYOU is set to 'true')
@@ -195,8 +203,10 @@ class DeliveryTool extends ToolModule
         $assignmentService = $this->getServiceLocator()->get(LtiAssignment::SERVICE_ID);
         if ($assignmentService->isDeliveryExecutionAllowed($delivery->getUri(), $user)) {
 
-            if (defined(FORCE_REDIRECT_TO_RETURNURL) &&  FORCE_REDIRECT_TO_RETURNURL === true) {
-                return $user->getLaunchData()->getVariable('launch_presentation_return_url');
+            $launchDataService = $this->getServiceLocator()->get(LtiLaunchDataService::SERVICE_ID);
+
+            if ($launchDataService->hasVariable(self::FORCE_REDIRECT_TO_RETURNURL)) {
+                    return $user->getLaunchData()->getVariable('launch_presentation_return_url');
             }
 
             return _url('ltiOverview', 'DeliveryRunner', null, ['delivery' => $delivery->getUri()]);

--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return [
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '11.4.3',
+    'version' => '11.5.0',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'generis' => '>=12.15.0',


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/NSUP-32
**Description:** TAO randomly not redirecting to postbackURL after test completion
**How to test:**  
1. pass test through LTI. 
2. run the test again with custom parameter '**force_redirect_to_return_url**'
![image](https://user-images.githubusercontent.com/18699340/95457162-24525380-0979-11eb-848f-47cc13ba1725.png)

After that you will be redirected to the 'Return URL' page