### PR TITLE
Feature TR-2434 - verify delivery execution time against allowed timeframe

### DIFF
--- a/test/unit/model/LtiAssignmentTest.php
+++ b/test/unit/model/LtiAssignmentTest.php
@@ -122,7 +122,7 @@ class LtiAssignmentTest extends TestCase
     /**
      * Test isDeliveryExecutionAllowed with LTI session with invalid (not numeric) max attempts value.
      */
-    public function testIsDeliveryExecutionAllowedNotNumericLtiMaxAttemptsLtiParameter()
+    public function testIsDeliveryExecutionAllowedThrowsExceptionWithNotNumericLtiMaxAttemptsLtiParameter()
     {
         $this->expectException(LtiClientException::class);
 
@@ -150,7 +150,7 @@ class LtiAssignmentTest extends TestCase
     /**
      * Test isDeliveryExecutionAllowed with LTI session with correct max attempts value, execution allowed.
      */
-    public function testIsDeliveryExecutionAllowedCorrectMaxAttemptsLtiParameter()
+    public function testIsDeliveryExecutionAllowedWithCorrectMaxAttemptsLtiParameter()
     {
         $this->sessionServiceMock->expects($this->once())
             ->method('getCurrentSession')
@@ -183,7 +183,7 @@ class LtiAssignmentTest extends TestCase
     /**
      * Test isDeliveryExecutionAllowed with more execution attempts than allowed.
      */
-    public function testIsDeliveryExecutionAllowedAttemptsLimitReached()
+    public function testIsDeliveryExecutionAllowedThrowsExceptionWhenAttemptsLimitReached()
     {
         $this->expectAttemptLimitException();
 
@@ -199,7 +199,7 @@ class LtiAssignmentTest extends TestCase
         $this->object->isDeliveryExecutionAllowed('URI', $this->userMock);
     }
 
-    public function testIsDeliveryExecutionAllowedTimeFrameViolatedByStartDate()
+    public function testIsDeliveryExecutionAllowedThrowsExceptionWhenTimeFrameViolatedByStartDate()
     {
         $this->expectTimeFrameViolationException();
 
@@ -210,7 +210,7 @@ class LtiAssignmentTest extends TestCase
         $this->object->isDeliveryExecutionAllowed('URI', $this->userMock);
     }
 
-    public function testIsDeliveryExecutionAllowedTimeFrameViolatedByEndDate()
+    public function testIsDeliveryExecutionAllowedThrowsExceptionWhenTimeFrameViolatedByEndDate()
     {
         $this->expectTimeFrameViolationException();
 
@@ -221,7 +221,7 @@ class LtiAssignmentTest extends TestCase
         $this->object->isDeliveryExecutionAllowed('URI', $this->userMock);
     }
 
-    public function testIsDeliveryExecutionTooEarly()
+    public function testIsDeliveryExecutionAllowedThrowsExceptionWhenItIsTooEarly()
     {
         $this->expectTimeFrameViolationException();
 
@@ -235,7 +235,7 @@ class LtiAssignmentTest extends TestCase
         $this->object->isDeliveryExecutionAllowed('URI', $this->userMock);
     }
 
-    public function testIsDeliveryExecutionTooLate()
+    public function testIsDeliveryExecutionAllowedThrowsExceptionWhenItIsTooLate()
     {
         $this->expectTimeFrameViolationException();
 


### PR DESCRIPTION
# [TR-2434](https://oat-sa.atlassian.net/browse/TR-2434)

- chore: make `LtiAssignmentTest` cases more flexible by relying on a Delivery entity properties map instead of mocking each property-retrieval method
- feat: verify delivery execution time against `TAODelivery.rdf#PeriodStart` and `TAODelivery.rdf#PeriodEnd` when attempting an LTI launch

## How to test
1. Set up TAO as an LTI 1.3 tool
2. Publish a delivery
3. Set its start and (or) end date
4. Launch that delivery's execution

https://user-images.githubusercontent.com/2943256/139258066-90202a36-0055-43f6-a921-fd9bd537ec9e.mov

## Test environment
- [Tool](https://delivery.test-infosign.playground.kitchen.it.taocloud.org/) ([credentials](http://playground.kitchen.it.taocloud.org/?p=test-infosign_delivery.git;a=blob;f=app/admin.txt;h=33580fdd1abc3b24876d123d4541a1fe5bef76fc;hb=HEAD))
- [Platform](https://devkit-oat-demo.dev.gcp-eu.taocloud.org/platform/message/launch/lti-resource-link?registration=infosignTestToolRegistration&user_type=custom&custom_user_id=MODIFY_ME&launch_url=https://delivery.test-infosign.playground.kitchen.it.taocloud.org/ltiDeliveryProvider/DeliveryTool/launch1p3?delivery%3Dhttp%253A%252F%252Fdelivery.test-infosign.playground.kitchen.it.taocloud.org%252Ftao.rdf%2523i617bd2cea4545185e034c58924ecefcb&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D,%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/resource_link%22:%20%7B%0D%0A%20%20%20%20%20%20%20%20%22id%22:%20%22resource_id_1%22%0D%0A%20%20%20%20%7D%0D%0A%7D)
