### PR TITLE
Feature TR-2744 optionally maintain delivery execution state on restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ As a system administrator you also install it through the TAO Extension Manager:
 
 ## Configuration options
 
+### Feature flags
+#### FEATURE_FLAG_MAINTAIN_RESTARTED_DELIVERY_EXECUTION_STATE
+A `bool`-typed environment variable, controlling whether a delivery execution state should be kept as is or reset each time it starts.
+- `"false"` – the state will be reset on each restart. Default behavior.
+- `"true"` – the state will be maintained upon a restart.
+
 ### LaunchQueue.conf.php
 
 #### Configuration option `relaunchInterval`

--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -24,14 +24,11 @@ use common_ext_ExtensionsManager;
 use common_Logger;
 use common_session_SessionManager;
 use core_kernel_classes_Resource;
-
-use tao_helpers_I18n;
-use function GuzzleHttp\Psr7\stream_for;
-
 use oat\ltiDeliveryProvider\model\execution\LtiDeliveryExecutionService;
 use oat\ltiDeliveryProvider\model\LtiAssignment;
 use oat\ltiDeliveryProvider\model\LTIDeliveryTool;
 use oat\ltiDeliveryProvider\model\LtiLaunchDataService;
+use oat\ltiDeliveryProvider\model\navigation\LtiNavigationService;
 use oat\tao\model\actionQueue\ActionFullException;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoDelivery\model\execution\StateServiceInterface;
@@ -42,8 +39,10 @@ use oat\taoLti\models\classes\LtiRoles;
 use oat\taoLti\models\classes\LtiService;
 use oat\taoLti\models\classes\LtiVariableMissingException;
 use oat\taoQtiTest\models\QtiTestExtractionFailedException;
+use tao_helpers_I18n;
 use tao_helpers_Uri;
-use oat\ltiDeliveryProvider\model\navigation\LtiNavigationService;
+
+use function GuzzleHttp\Psr7\stream_for;
 
 class DeliveryTool extends ToolModule
 {

--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -122,8 +122,7 @@ class DeliveryTool extends ToolModule
                         $activeExecution = $this->getActiveDeliveryExecution($compiledDelivery);
 
                         if ($activeExecution && $activeExecution->getState()->getUri() !== DeliveryExecution::STATE_PAUSED) {
-                            $deliveryExecutionStateService = $this->getServiceLocator()->get(StateServiceInterface::SERVICE_ID);
-                            $deliveryExecutionStateService->pause($activeExecution);
+                            $this->getStateService()->pause($activeExecution);
                         }
                         $this->redirect($this->getLearnerUrl($compiledDelivery, $activeExecution));
                     } catch (QtiTestExtractionFailedException $e) {
@@ -299,5 +298,10 @@ class DeliveryTool extends ToolModule
             ->getExtensionById('ltiDeliveryProvider');
 
         tao_helpers_I18n::init($extension, DEFAULT_ANONYMOUS_INTERFACE_LANG);
+    }
+
+    private function getStateService(): StateServiceInterface
+    {
+        return $this->getPsrContainer()->get(StateServiceInterface::SERVICE_ID);
     }
 }

--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -121,9 +121,7 @@ class DeliveryTool extends ToolModule
                     try {
                         $activeExecution = $this->getActiveDeliveryExecution($compiledDelivery);
 
-                        if ($activeExecution && $activeExecution->getState()->getUri() !== DeliveryExecution::STATE_PAUSED) {
-                            $this->getStateService()->pause($activeExecution);
-                        }
+                        $this->resetDeliveryExecutionState($activeExecution);
                         $this->redirect($this->getLearnerUrl($compiledDelivery, $activeExecution));
                     } catch (QtiTestExtractionFailedException $e) {
                         common_Logger::i($e->getMessage());
@@ -298,6 +296,15 @@ class DeliveryTool extends ToolModule
             ->getExtensionById('ltiDeliveryProvider');
 
         tao_helpers_I18n::init($extension, DEFAULT_ANONYMOUS_INTERFACE_LANG);
+    }
+
+    private function resetDeliveryExecutionState(DeliveryExecution $activeExecution = null): void
+    {
+        if (null === $activeExecution || $activeExecution->getState()->getUri() === DeliveryExecution::STATE_PAUSED) {
+            return;
+        }
+
+        $this->getStateService()->pause($activeExecution);
     }
 
     private function getStateService(): StateServiceInterface

--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -114,14 +114,14 @@ class DeliveryTool extends ToolModule
             $isLearner = !is_null($user)
                 && count(array_intersect([LtiRoles::CONTEXT_LEARNER, LtiRoles::CONTEXT_LTI1P3_LEARNER], $user->getRoles())) > 0;
 
-            $isDryRun = !$isLearner && in_array(LtiRoles::CONTEXT_LTI1P3_INSTRUCTOR, $user->getRoles());
+            $isDryRun = !$isLearner && in_array(LtiRoles::CONTEXT_LTI1P3_INSTRUCTOR, $user->getRoles(), true);
 
             if ($isLearner || $isDryRun) {
                 if ($this->hasAccess(DeliveryRunner::class, 'runDeliveryExecution')) {
                     try {
                         $activeExecution = $this->getActiveDeliveryExecution($compiledDelivery);
 
-                        if ($activeExecution && $activeExecution->getState()->getUri() != DeliveryExecution::STATE_PAUSED) {
+                        if ($activeExecution && $activeExecution->getState()->getUri() !== DeliveryExecution::STATE_PAUSED) {
                             $deliveryExecutionStateService = $this->getServiceLocator()->get(StateServiceInterface::SERVICE_ID);
                             $deliveryExecutionStateService->pause($activeExecution);
                         }


### PR DESCRIPTION
# [TR-2744](https://oat-sa.atlassian.net/browse/TR-2744)

## Changelog
- fix(codestyle): imports of `DeliveryTool`
- chore: apply strict comparisons to `DeliveryTool::run()` body
- fix: use PSR container to locate `StateServiceInterface` implementation in `DeliveryTool::run()`
- chore: extract active delivery execution state reset into `DeliveryTool::resetDeliveryExecutionState()`
- feat: introduce `FEATURE_FLAG_MAINTAIN_RESTARTED_DELIVERY_EXECUTION_STATE`, allowing to control whether a delivery execution state should be kept as is or reset each time it starts
- chore: document `FEATURE_FLAG_MAINTAIN_RESTARTED_DELIVERY_EXECUTION_STATE` behavior

https://user-images.githubusercontent.com/2943256/147127471-6f16da2c-4d9a-419b-a994-161a7e97bd36.mov

## How to test
1. Set [ltiProctoring](https://github.com/oat-sa/extension-lti-proctoring) up
2. Run a proctored assessment as a test taker
3. Authorize the assessment as a proctor
4. Restart the assessment as the test taker
5. Observe that the assessment state was reset
6. Authorize the assessment once more
7. Set `FEATURE_FLAG_MAINTAIN_RESTARTED_DELIVERY_EXECUTION_STATE="true"` environment variable
8. Restart the assessment as the test taker
9. Observe that the assessment remained authorized, and the test taker was able to start it immediately