### PR TITLE
feature: AGS request retrier

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ As a system administrator you also install it through the TAO Extension Manager:
 A `bool`-typed environment variable, controlling whether a delivery execution state should be kept as is or reset each time it starts.
 - `"false"` – the state will be reset on each restart. Default behavior.
 - `"true"` – the state will be maintained upon a restart.
+#### FEATURE_FLAG_AGS_SCORE_SENDING_RETRY
+A `bool`-typed environment variable, controlling whether AGS score should be resent if it fails to be sent.
 
 ### LaunchQueue.conf.php
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ A `bool`-typed environment variable, controlling whether a delivery execution st
 - `"true"` – the state will be maintained upon a restart.
 #### FEATURE_FLAG_AGS_SCORE_SENDING_RETRY
 A `bool`-typed environment variable, controlling whether AGS score should be resent if it fails to be sent.
+- `"false"` – the application won't try to resend another request when it fails. Default behavior.
+- `"true"` – the application will try to resend requests until the number of max retries is reached.
 
 ### LaunchQueue.conf.php
 

--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2021-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 
@@ -44,6 +44,8 @@ use qtism\runtime\tests\AssessmentTestSession;
 
 class LtiAgsListener extends ConfigurableService
 {
+    public const OPTION_AGS_MAX_RETRY = 5;
+
     public function onDeliveryExecutionStart(DeliveryExecutionCreated $event): void
     {
         $user = $event->getUser();
@@ -117,6 +119,8 @@ class LtiAgsListener extends ConfigurableService
             /** @var QueueDispatcherInterface $taskQueue */
             $taskQueue = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
             $taskQueue->createTask(new SendAgsScoreTask(), [
+                SendAgsScoreTask::RETRY_MAX => $this->getAgsMaxRetries(),
+                SendAgsScoreTask::RETRY_COUNT => 0,
                 'registrationId' => $user->getRegistrationId(),
                 'agsClaim' => $agsClaim->normalize(),
                 'data' => [
@@ -146,5 +150,10 @@ class LtiAgsListener extends ConfigurableService
         }
 
         return false;
+    }
+
+    private function getAgsMaxRetries(): int
+    {
+        return $this->getOption(self::OPTION_AGS_MAX_RETRY, 5);
     }
 }

--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -44,13 +44,14 @@ use qtism\runtime\tests\AssessmentTestSession;
 
 class LtiAgsListener extends ConfigurableService
 {
-    public const OPTION_AGS_MAX_RETRY = 5;
+    public const OPTION_AGS_MAX_RETRY = 'ags_max_retries';
 
     public function onDeliveryExecutionStart(DeliveryExecutionCreated $event): void
     {
         $user = $event->getUser();
 
         if ($user instanceof Lti1p3User && $user->getLaunchData()->hasVariable(LtiLaunchData::AGS_CLAIMS)) {
+
             /** @var AgsClaim $agsClaim */
             $agsClaim = $user->getLaunchData()->getVariable(LtiLaunchData::AGS_CLAIMS);
 
@@ -119,8 +120,7 @@ class LtiAgsListener extends ConfigurableService
             /** @var QueueDispatcherInterface $taskQueue */
             $taskQueue = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
             $taskQueue->createTask(new SendAgsScoreTask(), [
-                SendAgsScoreTask::RETRY_MAX => $this->getAgsMaxRetries(),
-                SendAgsScoreTask::RETRY_COUNT => 0,
+                'retryMax' => $this->getAgsMaxRetries(),
                 'registrationId' => $user->getRegistrationId(),
                 'agsClaim' => $agsClaim->normalize(),
                 'data' => [


### PR DESCRIPTION
## Ticket
https://oat-sa.atlassian.net/browse/TR-3182

## Summary
Implement a retry mechanism in the AGS scores sending flow so that the application will try to resend the request whenever it fails.

`FEATURE_FLAG_AGS_SCORE_SENDING_RETRY` should be set to true for enabling this feature

## How to test
1. 

## Dependencies
No dependencies

## Sandbox environment
TODO

