### PR TITLE
Use error-control operation in LtiAssignment to avoid array offset issue

### DIFF
--- a/model/LtiAssignment.php
+++ b/model/LtiAssignment.php
@@ -119,7 +119,7 @@ class LtiAssignment extends ConfigurableService
 
     private function verifyAvailabilityFrame(KernelResource $delivery): void
     {
-        [[$scheduledStartTimeProperty], [$scheduledEndTimeProperty]] = array_values($delivery->getPropertiesValues(
+        @[[$scheduledStartTimeProperty], [$scheduledEndTimeProperty]] = array_values($delivery->getPropertiesValues(
             [
                 $this->getProperty(DeliveryAssemblyService::PROPERTY_START),
                 $this->getProperty(DeliveryAssemblyService::PROPERTY_END),


### PR DESCRIPTION
## Ticket
https://oat-sa.atlassian.net/browse/TR-3181

## Summary
The previous solution was generating an index offset notice when the properties "PeriodStart" and "PeriodEnd" were not set in the delivery.

## How to test
1. Launch a test without the properties "PeriodStart" and "PeriodEnd" set through LTI 1.3
2. Watch the logs

Expected: The test should launch without issues and the log message `PHP Notice: Undefined offset: 0 in /var/www/html/ltiDeliveryProvider/model/LtiAssignment.php on line 125` is gone.

## Sandbox environment
TODO