### PR TITLE
Feature/tr 3948 add own graduated feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,11 @@ A `bool`-typed environment variable, controlling whether a delivery execution st
 A `bool`-typed environment variable, controlling whether AGS score should be resent if it fails to be sent.
 - `"false"` – the application won't try to resend another request when it fails. Default behavior.
 - `"true"` – the application will try to resend requests until the number of max retries is reached.
-
+#### FEATURE_FLAG_SCORING_OWNS_GRADING_PROGRESS
+A `bool`- typed environment variable, controlling whether gradingProgress property state on delivery execution finish.
+- `"false"` – the application send an AGS score publish request with a gradingStatus of fullyGraded.
+- `"true"` – send an AGS score to publish request with a gradingStatus of notReady.
+ 
 ### LaunchQueue.conf.php
 
 #### Configuration option `relaunchInterval`

--- a/README.md
+++ b/README.md
@@ -161,3 +161,10 @@ This parameter will always be set to a delivery execution state label.
 
 ## Extension Wiki
 You can find the [extension wiki here](https://github.com/oat-sa/extension-tao-ltideliveryprovider/wiki).
+
+## Feature flgs
+Here you can find the environment variables including feature flags
+
+| Variable                                   | Description                                                            | Default value |
+|--------------------------------------------|------------------------------------------------------------------------|---------------|
+| FEATURE_FLAG_SCORING_OWNS_GRADING_PROGRESS | Outcome of the test, summing both automatic scores and manual scores   | false         |

--- a/migrations/Version202204281419021874_ltiDeliveryProvider.php
+++ b/migrations/Version202204281419021874_ltiDeliveryProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\ltiDeliveryProvider\model\events\LtiAgsListener;
+use oat\generis\model\DependencyInjection\ServiceOptions;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202204281419021874_ltiDeliveryProvider extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Enable this option will change the mechanic of sending AGS status on survey complete from '
+            . 'completed to not ready';
+    }
+
+    public function up(Schema $schema): void
+    {
+        /** @var FeatureFlagCheckerInterface $featureFlagChecker */
+        $featureFlagChecker = $this->getServiceLocator()->get(FeatureFlagCheckerInterface::class);
+
+        $this->getServiceLocator()
+            ->get(ServiceOptions::SERVICE_ID)
+            ->save(
+                LtiAgsListener::SERVICE_ID,
+                LtiAgsListener::OPTION_SCORING_OWNS_GRADING_PROGRESS,
+                $featureFlagChecker->isEnabled(FeatureFlagCheckerInterface::FEATURE_FLAG_SCORING_OWNS_GRADING_PROGRESS)
+            );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->getServiceLocator()
+            ->get(ServiceOptions::SERVICE_ID)
+            ->remove(LtiAgsListener::SERVICE_ID, LtiAgsListener::OPTION_SCORING_OWNS_GRADING_PROGRESS);
+    }
+}

--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -83,6 +83,19 @@ class LtiAgsListener extends ConfigurableService
         }
     }
 
+    public function isScoringOwnsGradingProgressEnabled(): bool
+    {
+        /** @var FeatureFlagCheckerInterface $featureFlagChecker */
+        $featureFlagChecker = $this->getServiceLocator()->get(FeatureFlagCheckerInterface::class);
+        return $this->getServiceLocator()
+            ->get(ServiceOptions::SERVICE_ID)
+            ->get(
+                self::SERVICE_ID
+                , self::OPTION_SCORING_OWNS_GRADING_PROGRESS
+                , $featureFlagChecker->isEnabled(FeatureFlagCheckerInterface::FEATURE_FLAG_SCORING_OWNS_GRADING_PROGRESS)
+            );
+    }
+
     private function onDeliveryExecutionFinish(DeliveryExecutionState $event): void
     {
         /** @var User $user */
@@ -165,17 +178,6 @@ class LtiAgsListener extends ConfigurableService
         return $this->getOption(self::OPTION_AGS_MAX_RETRY, 5);
     }
 
-    private function isScoringOwnsGradingProgressEnabled(): int
-    {
-        /** @var FeatureFlagCheckerInterface $featureFlagChecker */
-        $featureFlagChecker = $this->getServiceLocator()->get(FeatureFlagCheckerInterface::class);
-        return $this->getServiceLocator()
-            ->get(ServiceOptions::SERVICE_ID)
-            ->get(
-                self::SERVICE_ID
-                , self::OPTION_SCORING_OWNS_GRADING_PROGRESS
-                , $featureFlagChecker->isEnabled(FeatureFlagCheckerInterface::FEATURE_FLAG_SCORING_OWNS_GRADING_PROGRESS)
-            );
-    }
+
 
 }

--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -96,6 +96,11 @@ class LtiAgsListener extends ConfigurableService
             );
     }
 
+    public function getQueueDispatcher(): QueueDispatcherInterface
+    {
+         return $this->getServiceManager()->get(QueueDispatcherInterface::SERVICE_ID);
+    }
+
     private function onDeliveryExecutionFinish(DeliveryExecutionState $event): void
     {
         /** @var User $user */
@@ -135,8 +140,7 @@ class LtiAgsListener extends ConfigurableService
             }
 
             /** @var QueueDispatcherInterface $taskQueue */
-            $taskQueue = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
-            $taskQueue->createTask(new SendAgsScoreTask(), [
+            $this->getQueueDispatcher()->createTask(new SendAgsScoreTask(), [
                 'retryMax' => $this->getAgsMaxRetries(),
                 'registrationId' => $user->getRegistrationId(),
                 'agsClaim' => $agsClaim->normalize(),

--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -29,7 +29,7 @@ use OAT\Library\Lti1p3Core\Message\Payload\Claim\AgsClaim;
 use oat\ltiDeliveryProvider\model\tasks\SendAgsScoreTask;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\user\User;
-use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
 use oat\tao\model\taskQueue\QueueDispatcherInterface;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
@@ -49,6 +49,7 @@ class LtiAgsListener extends ConfigurableService
     public const SERVICE_ID ='ltiDeliveryProvider/LtiAgsListener';
     public const OPTION_AGS_MAX_RETRY = 'ags_max_retries';
     public const OPTION_SCORING_OWNS_GRADING_PROGRESS = 'scoring_owns_grading_progress';
+    public const FEATURE_FLAG_SCORING_OWNS_GRADING_PROGRESS = 'FEATURE_FLAG_SCORING_OWNS_GRADING_PROGRESS';
 
     public function onDeliveryExecutionStart(DeliveryExecutionCreated $event): void
     {
@@ -85,14 +86,14 @@ class LtiAgsListener extends ConfigurableService
 
     public function isScoringOwnsGradingProgressEnabled(): bool
     {
-        /** @var FeatureFlagCheckerInterface $featureFlagChecker */
-        $featureFlagChecker = $this->getServiceLocator()->get(FeatureFlagCheckerInterface::class);
+        /** @var FeatureFlagChecker $featureFlagChecker */
+        $featureFlagChecker = $this->getServiceLocator()->get(FeatureFlagChecker::class);
         return $this->getServiceLocator()
             ->get(ServiceOptions::SERVICE_ID)
             ->get(
                 self::SERVICE_ID
                 , self::OPTION_SCORING_OWNS_GRADING_PROGRESS
-                , $featureFlagChecker->isEnabled(FeatureFlagCheckerInterface::FEATURE_FLAG_SCORING_OWNS_GRADING_PROGRESS)
+                , $featureFlagChecker->isEnabled(self::FEATURE_FLAG_SCORING_OWNS_GRADING_PROGRESS)
             );
     }
 

--- a/scripts/tools/SetOptionScoringOwnsGradingProgress.php
+++ b/scripts/tools/SetOptionScoringOwnsGradingProgress.php
@@ -1,0 +1,36 @@
+<?php
+
+use oat\oatbox\extension\script\ScriptAction;
+use oat\ltiDeliveryProvider\model\events\LtiAgsListener;
+use oat\generis\model\DependencyInjection\ServiceOptions;
+
+class SetOptionScoringOwnsGradingProgress extends ScriptAction
+{
+    protected function provideDescription()
+    {
+        return 'SCORE outcome of the test, summing both automatic scores and manual scores (when relevant)';
+    }
+
+    protected function provideOptions()
+    {
+        return [
+            'enableOwnGrading' => [
+                'longPrefix' => 'enableOwnGrading',
+                'required' => false,
+                'description' => 'Enable this option will change the mechanic of sending AGS status on survey complete from to not ready',
+                'defaultValue' => false
+            ],
+        ];
+    }
+
+    protected function run()
+    {
+        $this->getServiceManager()
+            ->get(ServiceOptions::SERVICE_ID)
+            ->save(
+                LtiAgsListener::SERVICE_ID
+                , LtiAgsListener::OPTION_SCORING_OWNS_GRADING_PROGRESS
+                , $this->getOption('enableOwnGrading')
+            );
+    }
+}

--- a/test/unit/model/events/LtiAgsListenerTest.php
+++ b/test/unit/model/events/LtiAgsListenerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\test\unit\model\events;
+
+use oat\generis\test\MockObject;
+use OAT\Library\Lti1p3Ags\Model\Score\ScoreInterface;
+use oat\oatbox\user\User;
+use oat\tao\model\taskQueue\QueueDispatcherInterface;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionStateContext;
+use \PHPUnit\Framework\TestCase;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
+use oat\ltiDeliveryProvider\model\events\LtiAgsListener;
+
+class LtiAgsListenerTest extends TestCase
+{
+    /** @var DeliveryExecutionState  */
+    private $event;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $deliveryExecutionMock = $this->createMock(DeliveryExecutionInterface::class);
+
+        $deliveryExecutionContext = new DeliveryExecutionStateContext([
+            DeliveryExecutionStateContext::PARAM_USER => $this->createMock(User::class)
+        ]);
+
+        $this->event = new DeliveryExecutionState(
+            $deliveryExecutionMock,
+            DeliveryExecutionInterface::STATE_FINISHED,
+            DeliveryExecutionInterface::STATE_ACTIVE,
+            $deliveryExecutionContext
+        );
+    }
+
+
+    public function testSendNotReadyStatusIfScoringOwnsGradingProgressEnabled()
+    {
+        $subject = $this->createMock(LtiAgsListener::class);
+        $subject->method('isScoringOwnsGradingProgressEnabled')
+            ->willReturn(true);
+
+        $gradingProgress = ScoreInterface::GRADING_PROGRESS_STATUS_FULLY_GRADED;
+        $this->createMock(
+            QueueDispatcherInterface::class
+        )
+            ->method('createTask')
+            ->with(
+                $this->callback(
+                    function ($class, $params) use(&$gradingProgress) {
+                        $gradingProgress = $params['data']['gradingProgress'];
+                    }
+                )
+            );
+
+        $subject->onDeliveryExecutionStateUpdate($this->event);
+
+        $this->assertEquals($gradingProgress, ScoreInterface::GRADING_PROGRESS_STATUS_NOT_READY);
+    }
+
+    public function testSendNotReadyStatusIfScoringOwnsGradingProgressDisable()
+    {
+        $subject = $this->createMock(LtiAgsListener::class);
+        $subject->method('isScoringOwnsGradingProgressEnabled')
+            ->willReturn(false);
+
+        $gradingProgress = ScoreInterface::GRADING_PROGRESS_STATUS_FULLY_GRADED;
+        $this->createMock(
+            QueueDispatcherInterface::class
+        )
+            ->method('createTask')
+            ->with(
+                $this->callback(
+                    function ($class, $params) use(&$gradingProgress) {
+                        $gradingProgress = $params['data']['gradingProgress'];
+                    }
+                )
+            );
+
+        $subject->onDeliveryExecutionStateUpdate($this->event);
+
+        $this->assertEquals($gradingProgress, ScoreInterface::GRADING_PROGRESS_STATUS_NOT_READY);
+    }
+}


### PR DESCRIPTION
# [TR-3948](https://oat-sa.atlassian.net/browse/TR-3948)

# AC

 1. GIVEN a Terre instance that IS NOT LINKED to a Scoring Service
 2.  WHEN the test-taker submits his test
 3. THEN send an AGS score publish request with a gradingStatus of fullyGraded (this is existing functionality)

  1. GIVEN a Terre instance that IS LINKED to a Scoring Service
  2.  WHEN the test-taker submits his test
  3. THEN send an AGS score to publish request with a gradingStatus of notReady
-----

In implementation I left 2 ways via FLAG feature and old with options, because we probably would have a situation when we host 2 client on 1 server and one of it that feature don't need. 

Turn off that option should have been done in 2 ways: 
1. Bu command
2. By env variables  (flag)

------
## Response example 
```
{
  "retryMax": 5,
  "registrationId": "http://backoffice.docker.localhost/ontologies/tao.rdf#i6270fb4fe39f884f151af5626eb0bb",
  "agsClaim": {
    "scope": [
      "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
      "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
      "https://purl.imsglobal.org/spec/lti-ags/scope/score"
    ],
    "lineitems": "http://devkit.docker.localhost/platform/service/ags/test/lineitems",
    "lineitem": "http://devkit.docker.localhost/platform/service/ags/test/lineitems/test"
  },
  "data": {
    "userId": "anonymous",
    "activityProgress": "Completed",
    "gradingProgress": "NotReady",
    "scoreGiven": null,
    "scoreMaximum": null
  }
}

```
----- 
## Test 

https://user-images.githubusercontent.com/2750628/166438390-26368fb5-3600-4e51-97e6-b35cd0078580.mov


