### PR TITLE
fix: use proper classname

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -16,7 +16,7 @@ jobs:
         operating-system: [ ubuntu-latest ]
         php-version: [ '7.4', '8.0', '8.1' ]
         include:
-          - php-version: '7.4'
+          - php-version: '8.1'
             coverage: true
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -70,5 +70,9 @@
 		"oat-sa/extension-tao-outcomeui" : ">=10.0.0",
 		"oat-sa/extension-tao-testqti" : ">=42.2.0",
 		"oat-sa/extension-tao-outcome" : ">=13.0.0"
-	}
+	},
+    "require-dev": {
+        "oat-sa/generis": "dev-php8-migration as v16.0.0",
+        "oat-sa/tao-core": "dev-php8-migration as v51.0.0"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -62,17 +62,13 @@
     "minimum-stability" : "dev",
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-		"oat-sa/generis" : ">=14.0.0",
-		"oat-sa/tao-core" : ">=48.56.0",
+		"oat-sa/generis" : ">=15.22",
+		"oat-sa/tao-core" : ">=50.24.6",
 		"oat-sa/extension-tao-delivery" : ">=15.8.0",
 		"oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
 		"oat-sa/extension-tao-lti" : ">=15.2.0",
 		"oat-sa/extension-tao-outcomeui" : ">=10.0.0",
 		"oat-sa/extension-tao-testqti" : ">=42.2.0",
 		"oat-sa/extension-tao-outcome" : ">=13.0.0"
-	},
-    "require-dev": {
-        "oat-sa/generis": "dev-php8-migration as v16.0.0",
-        "oat-sa/tao-core": "dev-php8-migration as v51.0.0"
-    }
+	}
 }

--- a/includes/raw_start.php
+++ b/includes/raw_start.php
@@ -16,21 +16,16 @@
  *
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
- *
- */
-?>
-<?php
-/**
- * RAW Bootstraping
- *
  * @author CRP Henri Tudor - TAO Team - {@link http://www.tao.lu}
  * @license GPLv2  http://www.opensource.org/licenses/gpl-2.0.php
  */
+
 if (PHP_SAPI == 'cli') {
     $_SERVER['HTTP_HOST'] = 'http://localhost';
     $_SERVER['DOCUMENT_ROOT'] = dirname(__FILE__) . '/../../..';
 }
+
 require_once dirname(__FILE__) . '/../../tao/includes/class.Bootstrap.php';
 
-$bootStrap = new BootStrap('taoDelivery');
+$bootStrap = new Bootstrap('taoDelivery');
 $bootStrap->start();


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1097
https://oat-sa.atlassian.net/browse/ADF-1087
https://oat-sa.atlassian.net/browse/ADF-1105

## Goal 

Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.