### PR TITLE
Feature ADF-1102 CI pipeline

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,27 @@
+name: Continuous integration
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php-version: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        include:
+          - php-version: '7.2'
+            coverage: true
+
+    steps:
+      - name: CI
+        uses: oat-sa/tao-extension-ci-action@v1
+        with:
+          php: ${{ matrix.php-version }}
+          coverage: ${{ matrix.coverage }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php-version: [ '7.4', '8.0', '8.1' ]
         include:
-          - php-version: '7.2'
+          - php-version: '7.4'
             coverage: true
 
     steps:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![GitHub](https://img.shields.io/github/license/oat-sa/extension-tao-ltideliveryprovider.svg)
 ![GitHub release](https://img.shields.io/github/release/oat-sa/extension-tao-ltideliveryprovider.svg)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/y/oat-sa/extension-tao-ltideliveryprovider.svg)
+[![codecov](https://codecov.io/gh/oat-sa/extension-tao-ltideliveryprovider/branch/master/graph/badge.svg)](https://codecov.io/gh/oat-sa/extension-tao-ltideliveryprovider)
 
 > The LTI Delivery extension allows test-takers to take a delivery (delivered test) via LTI
 


### PR DESCRIPTION
# [ADF-1102](https://oat-sa.atlassian.net/browse/ADF-1102)

This PR aims to integrate the extension with a new CI pipeline defined by https://github.com/oat-sa/tao-extension-ci-action

⚠️ It is expected that PHP > 7.4 pipeline fail ⚠️

## Changelog
- ci: add a CI action
- docs: add a codecov badge to README.md