### PR TITLE
Feature/tr 4778/extend ags send error log message payload with delivery execution

### DIFF
--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -49,6 +49,7 @@ class LtiAgsListener extends ConfigurableService
     public function onDeliveryExecutionStart(DeliveryExecutionCreated $event): void
     {
         $user = $event->getUser();
+        $deliveryExcecution = $event->getDeliveryExecution();
 
         if ($user instanceof Lti1p3User && $user->getLaunchData()->hasVariable(LtiLaunchData::AGS_CLAIMS)) {
 
@@ -59,6 +60,7 @@ class LtiAgsListener extends ConfigurableService
             $taskQueue = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
             $taskQueue->createTask(new SendAgsScoreTask(), [
                 'registrationId' => $user->getRegistrationId(),
+                'deliveryExecutionId' => $deliveryExcecution->getIdentifier(),
                 'agsClaim' => $agsClaim->normalize(),
                 'data' => [
                     'userId' => $user->getIdentifier(),

--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -49,7 +49,7 @@ class LtiAgsListener extends ConfigurableService
     public function onDeliveryExecutionStart(DeliveryExecutionCreated $event): void
     {
         $user = $event->getUser();
-        $deliveryExcecution = $event->getDeliveryExecution();
+        $deliveryExecution = $event->getDeliveryExecution();
 
         if ($user instanceof Lti1p3User && $user->getLaunchData()->hasVariable(LtiLaunchData::AGS_CLAIMS)) {
 
@@ -60,7 +60,7 @@ class LtiAgsListener extends ConfigurableService
             $taskQueue = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
             $taskQueue->createTask(new SendAgsScoreTask(), [
                 'registrationId' => $user->getRegistrationId(),
-                'deliveryExecutionId' => $deliveryExcecution->getIdentifier(),
+                'deliveryExecutionId' => $deliveryExecution->getIdentifier(),
                 'agsClaim' => $agsClaim->normalize(),
                 'data' => [
                     'userId' => $user->getIdentifier(),
@@ -85,6 +85,7 @@ class LtiAgsListener extends ConfigurableService
     {
         /** @var User $user */
         $user = $event->getContext()->getParameter(DeliveryExecutionStateContext::PARAM_USER);
+        $deliveryExecution = $event->getDeliveryExecution();
 
         if ($user instanceof Lti1p3User && $user->getLaunchData()->hasVariable(LtiLaunchData::AGS_CLAIMS)) {
             /** @var AgsClaim $agsClaim */
@@ -124,6 +125,7 @@ class LtiAgsListener extends ConfigurableService
             $taskQueue->createTask(new SendAgsScoreTask(), [
                 'retryMax' => $this->getAgsMaxRetries(),
                 'registrationId' => $user->getRegistrationId(),
+                'deliveryExecutionId' => $deliveryExecution->getIdentifier(),
                 'agsClaim' => $agsClaim->normalize(),
                 'data' => [
                     'userId' => $user->getIdentifier(),

--- a/model/tasks/SendAgsScoreTask.php
+++ b/model/tasks/SendAgsScoreTask.php
@@ -57,7 +57,7 @@ class SendAgsScoreTask extends AbstractAction
         }
 
         $registrationId = $params['registrationId'];
-        $deliveryExecutionId = $params['deliveryExecutionId'];
+        $deliveryExecutionId = $params['deliveryExecutionId'] ?? 'not passed to sender task';
         $agsClaim = AgsClaim::denormalize($params['agsClaim']);
         $data = $params['data'];
 

--- a/model/tasks/SendAgsScoreTask.php
+++ b/model/tasks/SendAgsScoreTask.php
@@ -42,7 +42,6 @@ class SendAgsScoreTask extends AbstractAction
     public const RETRY_COUNT = 'retryCount';
     public const RETRY_MAX = 'retryMax';
 
-    /** @var array */
     private array $params = [self::RETRY_COUNT => 0];
 
     public function __invoke($params): Report

--- a/model/tasks/SendAgsScoreTask.php
+++ b/model/tasks/SendAgsScoreTask.php
@@ -43,7 +43,7 @@ class SendAgsScoreTask extends AbstractAction
     public const RETRY_MAX = 'retryMax';
 
     /** @var array */
-    private $params = [self::RETRY_COUNT => 0];
+    private array $params = [self::RETRY_COUNT => 0];
 
     public function __invoke($params): Report
     {
@@ -128,7 +128,7 @@ class SendAgsScoreTask extends AbstractAction
         }
 
         $this->increaseRetryCount();
-        $this->getQueueDispatcher()->createTask(new self, $this->params);
+        $this->getQueueDispatcher()->createTask(new self(), $this->params);
         $this->logInfo('AGS Score message has been rescheduled for another try');
     }
 

--- a/model/tasks/SendAgsScoreTask.php
+++ b/model/tasks/SendAgsScoreTask.php
@@ -91,7 +91,7 @@ class SendAgsScoreTask extends AbstractAction
             throw new InvalidArgumentException('Parameter "registrationId" must be a string');
         }
 
-        if (!is_string($params['deliveryExecutionId'] ?? null)) {
+        if (isset($params['deliveryExecutionId']) && !is_string($params['deliveryExecutionId'])) {
             throw new InvalidArgumentException('Parameter "deliveryExecutionId" must be a string');
         }
 

--- a/test/unit/tasks/SendAgsScoreTaskTest.php
+++ b/test/unit/tasks/SendAgsScoreTaskTest.php
@@ -126,6 +126,7 @@ class SendAgsScoreTaskTest extends TestCase
         return [
             [
                 [
+                    'deliveryExecutionId' => 'some_id',
                     'registrationId' => 1, // invalid
                     'agsClaim' => [],
                     'data' => [],
@@ -134,6 +135,16 @@ class SendAgsScoreTaskTest extends TestCase
             ],
             [
                 [
+                    'deliveryExecutionId' => 1, // invalid
+                    'registrationId' => '',
+                    'agsClaim' => [],
+                    'data' => [],
+                ],
+                'Parameter "deliveryExecutionId" must be a string'
+            ],
+            [
+                [
+                    'deliveryExecutionId' => 'some_id',
                     'registrationId' => 'valid',
                     'agsClaim' => null, // invalid
                     'data' => [],
@@ -142,6 +153,7 @@ class SendAgsScoreTaskTest extends TestCase
             ],
             [
                 [
+                    'deliveryExecutionId' => 'some_id',
                     'registrationId' => 'valid',
                     'agsClaim' => [], // scope missing
                     'data' => [],
@@ -150,6 +162,7 @@ class SendAgsScoreTaskTest extends TestCase
             ],
             [
                 [
+                    'deliveryExecutionId' => 'some_id',
                     'registrationId' => 'valid',
                     'agsClaim' => [
                         'scope' => [
@@ -169,6 +182,7 @@ class SendAgsScoreTaskTest extends TestCase
     {
         return [
             'registrationId' => 'id',
+            'deliveryExecutionId' => 'id',
             'agsClaim' => [
                 'scope' => [
                     "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",


### PR DESCRIPTION
Extending critical log entry payload in order to be able to find related execution.