### PR TITLE
feat: store LTI delivery execution launch data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,9 +66,9 @@
 		"oat-sa/tao-core" : ">=50.24.6",
 		"oat-sa/extension-tao-delivery" : ">=15.8.0",
 		"oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
-		"oat-sa/extension-tao-lti" : ">=15.2.0",
+		"oat-sa/extension-tao-lti" : ">=15.11.0",
 		"oat-sa/extension-tao-outcomeui" : ">=10.0.0",
 		"oat-sa/extension-tao-testqti" : ">=42.2.0",
-		"oat-sa/extension-tao-outcome" : ">=13.0.0"
+		"oat-sa/extension-tao-outcome" : ">=13.3.0"
 	}
 }

--- a/manifest.php
+++ b/manifest.php
@@ -43,6 +43,7 @@ return [
     'label' => 'LTI Delivery Tool Provider',
     'description' => 'The LTI Delivery Tool Provider' .
         ' allows third party applications to embed deliveries created in Tao',
+
     'license' => 'GPL-2.0',
     'author' => 'Open Assessment Technologies',
     'models' => [

--- a/manifest.php
+++ b/manifest.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2023 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
 use oat\ltiDeliveryProvider\controller\DeliveryRunner;
@@ -24,6 +24,7 @@ use oat\ltiDeliveryProvider\controller\LinkConfiguration;
 use oat\ltiDeliveryProvider\install\InstallAssignmentService;
 use oat\ltiDeliveryProvider\install\InstallDeliveryContainerService;
 use oat\ltiDeliveryProvider\install\RegisterLaunchAction;
+use oat\ltiDeliveryProvider\model\serviceProvider\LtiDeliveryServiceProvider;
 use oat\ltiDeliveryProvider\scripts\e2e\BuildE2eConfiguration;
 use oat\ltiDeliveryProvider\scripts\install\RegisterLti1p3ResultServerServiceFactory;
 use oat\ltiDeliveryProvider\scripts\install\RegisterLtiAttemptService;
@@ -104,5 +105,7 @@ return [
     'e2ePrerequisiteActions' => [
         BuildE2eConfiguration::class
     ],
-
+    'containerServiceProviders' => [
+        LtiDeliveryServiceProvider::class
+    ],
 ];

--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,8 @@ use oat\taoLti\models\classes\LtiRoles;
 return [
     'name' => 'ltiDeliveryProvider',
     'label' => 'LTI Delivery Tool Provider',
-    'description' => 'The LTI Delivery Tool Provider allows third party applications to embed deliveries created in Tao',
+    'description' => 'The LTI Delivery Tool Provider' .
+        ' allows third party applications to embed deliveries created in Tao',
     'license' => 'GPL-2.0',
     'author' => 'Open Assessment Technologies',
     'models' => [
@@ -72,10 +73,14 @@ return [
     'update' => Updater::class,
     'managementRole' => 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LtiDeliveryProviderManagerRole',
     'acl' => [
-        ['grant', 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LtiDeliveryProviderManagerRole', ['ext' => 'ltiDeliveryProvider']],
+        ['grant', 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LtiDeliveryProviderManagerRole', [
+            'ext' => 'ltiDeliveryProvider'
+        ]],
         ['grant', TaoRoles::ANONYMOUS, ['ext' => 'ltiDeliveryProvider', 'mod' => 'DeliveryTool', 'act' => 'launch']],
         ['grant', TaoRoles::ANONYMOUS, ['ext' => 'ltiDeliveryProvider', 'mod' => 'DeliveryTool', 'act' => 'launch1p3']],
-        ['grant', 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LtiBaseRole', ['ext' => 'ltiDeliveryProvider', 'mod' => 'DeliveryTool', 'act' => 'run']],
+        ['grant', 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LtiBaseRole', [
+            'ext' => 'ltiDeliveryProvider', 'mod' => 'DeliveryTool', 'act' => 'run'
+        ]],
         ['grant', LtiRoles::CONTEXT_LEARNER, DeliveryRunner::class],
         ['grant', LtiRoles::CONTEXT_LTI1P3_LEARNER, DeliveryRunner::class],
         ['grant', LtiRoles::CONTEXT_LEARNER, DeliveryTool::class, 'launchQueue'],

--- a/migrations/Version202301111634748504_ltiDeliveryProvider.php
+++ b/migrations/Version202301111634748504_ltiDeliveryProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\ltiDeliveryProvider\model\events\LtiAgsListener;
+use oat\oatbox\event\EventManager;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoResultServer\models\Events\DeliveryExecutionResultsRecalculated;
+
+final class Version202301111634748504_ltiDeliveryProvider extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Register LtiAgsListener events';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $eventManager = $this->getServiceLocator()->get(EventManager::SERVICE_ID);
+
+        $eventManager->attach(
+            DeliveryExecutionResultsRecalculated::class,
+            [LtiAgsListener::class, 'onDeliveryExecutionResultsRecalculated']
+        );
+
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $eventManager = $this->getServiceLocator()->get(EventManager::SERVICE_ID);
+
+        $eventManager->detach(
+            DeliveryExecutionResultsRecalculated::class,
+            [LtiAgsListener::class, 'onDeliveryExecutionResultsRecalculated']
+        );
+
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+    }
+}

--- a/model/LTIDeliveryTool.php
+++ b/model/LTIDeliveryTool.php
@@ -98,13 +98,9 @@ class LTIDeliveryTool extends ConfigurableService
     /**
      * Start a new delivery execution
      *
-     * @param Resource $delivery
-     * @param Resource $link
-     * @param User $user
-     * @return DeliveryExecution
      * @throws \common_exception_Unauthorized
      */
-    public function startDelivery(Resource $delivery, Resource $link, User $user)
+    public function startDelivery(Resource $delivery, Resource $link, User $user): DeliveryExecution
     {
         $lock = $this->createLock(__METHOD__ . $delivery->getUri() . $user->getIdentifier(), 30);
         $lock->acquire(true);
@@ -147,8 +143,6 @@ class LTIDeliveryTool extends ConfigurableService
     /**
      * Returns an array of DeliveryExecution
      *
-     * @param Resource $delivery
-     * @param Resource $link
      * @param string $userId
      * @return array
      */
@@ -161,9 +155,9 @@ class LTIDeliveryTool extends ConfigurableService
     }
 
     /**
-     * Link `lis_result_sourcedid` to delivery execution in order to be able to retrieve delivery execution by lis_result_sourcedid
+     * Link `lis_result_sourcedid` to delivery execution
+     * in order to be able to retrieve delivery execution by lis_result_sourcedid
      *
-     * @param DeliveryExecution $deliveryExecution
      * @throws \common_exception_Error
      * @throws \oat\taoLti\models\classes\LtiException
      * @throws \oat\taoLti\models\classes\LtiVariableMissingException
@@ -186,7 +180,6 @@ class LTIDeliveryTool extends ConfigurableService
     }
 
     /**
-     * @return LtiLaunchData
      * @throws LtiException
      */
     protected function getLtiLaunchData(): LtiLaunchData

--- a/model/LTIDeliveryTool.php
+++ b/model/LTIDeliveryTool.php
@@ -120,11 +120,7 @@ class LTIDeliveryTool extends ConfigurableService
             ->createDeliveryExecutionLink($user->getIdentifier(), $link->getUri(), $deliveryExecution->getIdentifier());
         $lock->release();
 
-        /* @var LtiContextRepositoryInterface $contextRepository */
-        $contextRepository = $this->getServiceManager()
-            ->getContainer()
-            ->get(LtiContextRepositoryInterface::class);
-        $contextRepository->save($user->getLaunchData(), $deliveryExecution);
+        $this->storeLtiContext($this->getLtiLaunchData(), $deliveryExecution);
 
         return $deliveryExecution;
     }
@@ -172,7 +168,8 @@ class LTIDeliveryTool extends ConfigurableService
         // of the TC system or if the TC moved from one domain to another.
         $launchData = $this->getLtiLaunchData();
         $resultIdentifier = $launchData->hasVariable('lis_result_sourcedid')
-            ? $launchData->getVariable('lis_result_sourcedid') : $executionIdentifier;
+            ? $launchData->getVariable('lis_result_sourcedid')
+            : $executionIdentifier;
 
         /** @var LtiResultAliasStorage $ltiResultIdStorage */
         $ltiResultIdStorage = $this->getServiceLocator()->get(LtiResultAliasStorage::SERVICE_ID);
@@ -190,5 +187,17 @@ class LTIDeliveryTool extends ConfigurableService
         }
 
         return $session->getLaunchData();
+    }
+
+    private function storeLtiContext(LtiLaunchData $ltiLaunchData, $deliveryExecution): void
+    {
+        $this->getLtiContextRepository()->save($ltiLaunchData, $deliveryExecution);
+    }
+
+    private function getLtiContextRepository(): LtiContextRepositoryInterface
+    {
+        return $this->getServiceManager()
+            ->getContainer()
+            ->get(LtiContextRepositoryInterface::class);
     }
 }

--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -152,8 +152,8 @@ class LtiAgsListener extends ConfigurableService
         string $taskLabel,
         LtiLaunchData $ltiLaunchData,
         DeliveryExecutionInterface $deliveryExecution,
-        $scoreTotal,
-        $scoreTotalMax,
+        ?float $scoreTotal,
+        ?float $scoreTotalMax,
         string $gradingStatus
     ): void {
 

--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -83,7 +83,7 @@ class LtiAgsListener extends ConfigurableService
         }
     }
 
-    public function onDeliveryExecutionResultsRecalculated(DeliveryExecutionResultsRecalculated $event)
+    public function onDeliveryExecutionResultsRecalculated(DeliveryExecutionResultsRecalculated $event): void
     {
         $deliveryExecution = $event->getDeliveryExecution();
 
@@ -94,7 +94,7 @@ class LtiAgsListener extends ConfigurableService
                 $deliveryExecution,
                 $event->getScore(),
                 $event->getMaxScore(),
-                ScoreInterface::GRADING_PROGRESS_STATUS_FULLY_GRADED // Todo pass actual status TR-4952
+                ScoreInterface::GRADING_PROGRESS_STATUS_FULLY_GRADED //todo pass actual status
             );
         }
     }
@@ -152,8 +152,8 @@ class LtiAgsListener extends ConfigurableService
         string $taskLabel,
         LtiLaunchData $ltiLaunchData,
         DeliveryExecutionInterface $deliveryExecution,
-        ?float $scoreTotal,
-        ?float $scoreTotalMax,
+        $scoreTotal,
+        $scoreTotalMax,
         string $gradingStatus
     ): void {
 

--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2021-2023 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 
@@ -25,6 +25,7 @@ namespace oat\ltiDeliveryProvider\model\events;
 
 use OAT\Library\Lti1p3Ags\Model\Score\ScoreInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\Claim\AgsClaim;
+use oat\ltiDeliveryProvider\model\execution\LtiContextRepositoryInterface;
 use oat\ltiDeliveryProvider\model\tasks\SendAgsScoreTask;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\user\User;
@@ -36,6 +37,7 @@ use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionStateContext
 use oat\taoLti\models\classes\LtiLaunchData;
 use oat\taoLti\models\classes\user\Lti1p3User;
 use oat\taoQtiTest\models\TestSessionService;
+use oat\taoResultServer\models\Events\DeliveryExecutionResultsRecalculated;
 use qtism\common\datatypes\QtiScalar;
 use qtism\data\AssessmentItemRef;
 use qtism\data\state\OutcomeDeclaration;
@@ -81,19 +83,32 @@ class LtiAgsListener extends ConfigurableService
         }
     }
 
+    public function onDeliveryExecutionResultsRecalculated(DeliveryExecutionResultsRecalculated $event)
+    {
+        $deliveryExecution = $event->getDeliveryExecution();
+
+        if ($launchData = $this->getLtiContextRepository()->findByDeliveryExecution($deliveryExecution)) {
+            $this->queueSendAgsScoreTaskWithScores(
+                'AGS scores send on result recalculation',
+                $launchData,
+                $deliveryExecution,
+                $event->getScore(),
+                $event->getMaxScore(),
+                ScoreInterface::GRADING_PROGRESS_STATUS_FULLY_GRADED // Todo pass actual status TR-4952
+            );
+        }
+    }
+
     private function onDeliveryExecutionFinish(DeliveryExecutionState $event): void
     {
         /** @var User $user */
         $user = $event->getContext()->getParameter(DeliveryExecutionStateContext::PARAM_USER);
         $deliveryExecution = $event->getDeliveryExecution();
 
-        if ($user instanceof Lti1p3User && $user->getLaunchData()->hasVariable(LtiLaunchData::AGS_CLAIMS)) {
-            /** @var AgsClaim $agsClaim */
-            $agsClaim = $user->getLaunchData()->getVariable(LtiLaunchData::AGS_CLAIMS);
-
+        if ($user instanceof Lti1p3User) {
             /** @var TestSessionService $testSessionService */
             $testSessionService = $this->getServiceManager()->get(TestSessionService::SERVICE_ID);
-            $session = $testSessionService->getTestSession($event->getDeliveryExecution());
+            $session = $testSessionService->getTestSession($deliveryExecution);
 
             $scoreTotal = null;
             $scoreTotalMax = null;
@@ -120,24 +135,51 @@ class LtiAgsListener extends ConfigurableService
                 }
             }
 
-            /** @var QueueDispatcherInterface $taskQueue */
-            $taskQueue = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
-            $taskQueue->createTask(new SendAgsScoreTask(), [
-                'retryMax' => $this->getAgsMaxRetries(),
-                'registrationId' => $user->getRegistrationId(),
-                'deliveryExecutionId' => $deliveryExecution->getIdentifier(),
-                'agsClaim' => $agsClaim->normalize(),
-                'data' => [
-                    'userId' => $user->getIdentifier(),
-                    'activityProgress' => ScoreInterface::ACTIVITY_PROGRESS_STATUS_COMPLETED,
-                    'gradingProgress' => $this->isManualScored($session)
-                        ? ScoreInterface::GRADING_PROGRESS_STATUS_PENDING_MANUAL
-                        : ScoreInterface::GRADING_PROGRESS_STATUS_FULLY_GRADED,
-                    'scoreGiven' => $scoreTotal,
-                    'scoreMaximum' => $scoreTotalMax,
-                ]
-            ], 'AGS score send on test finish');
+            $this->queueSendAgsScoreTaskWithScores(
+                'AGS score send on test finish',
+                $user->getLaunchData(),
+                $deliveryExecution,
+                $scoreTotal,
+                $scoreTotalMax,
+                $this->isManualScored($session)
+                    ? ScoreInterface::GRADING_PROGRESS_STATUS_PENDING_MANUAL
+                    : ScoreInterface::GRADING_PROGRESS_STATUS_FULLY_GRADED
+            );
         }
+    }
+
+    private function queueSendAgsScoreTaskWithScores(
+        string $taskLabel,
+        LtiLaunchData $ltiLaunchData,
+        DeliveryExecutionInterface $deliveryExecution,
+        $scoreTotal,
+        $scoreTotalMax,
+        string $gradingStatus
+    ): void {
+
+        if (!$ltiLaunchData->hasVariable(LtiLaunchData::AGS_CLAIMS)) {
+            return;
+        }
+
+        $agsClaim = $ltiLaunchData->getVariable(LtiLaunchData::AGS_CLAIMS);
+        $registrationId = $ltiLaunchData->getVariable(LtiLaunchData::TOOL_CONSUMER_INSTANCE_ID);
+        $userId = $deliveryExecution->getUserIdentifier();
+
+        /** @var QueueDispatcherInterface $taskQueue */
+        $taskQueue = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
+        $taskQueue->createTask(new SendAgsScoreTask(), [
+            'retryMax' => $this->getAgsMaxRetries(),
+            'registrationId' => $registrationId,
+            'deliveryExecutionId' => $deliveryExecution->getIdentifier(),
+            'agsClaim' => $agsClaim->normalize(),
+            'data' => [
+                'userId' => $userId,
+                'activityProgress' => ScoreInterface::ACTIVITY_PROGRESS_STATUS_COMPLETED,
+                'gradingProgress' => $gradingStatus,
+                'scoreGiven' => $scoreTotal,
+                'scoreMaximum' => $scoreTotalMax,
+            ]
+        ], $taskLabel);
     }
 
     private function isManualScored(AssessmentTestSession $session): bool
@@ -159,5 +201,10 @@ class LtiAgsListener extends ConfigurableService
     private function getAgsMaxRetries(): int
     {
         return $this->getOption(self::OPTION_AGS_MAX_RETRY, 5);
+    }
+
+    private function getLtiContextRepository(): LtiContextRepositoryInterface
+    {
+        return $this->getServiceManager()->getContainer()->get(LtiContextRepositoryInterface::class);
     }
 }

--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -92,8 +92,8 @@ class LtiAgsListener extends ConfigurableService
                 'AGS scores send on result recalculation',
                 $launchData,
                 $deliveryExecution,
-                $event->getScore(),
-                $event->getMaxScore(),
+                $event->getTotalScore(),
+                $event->getTotalMaxScore(),
                 ScoreInterface::GRADING_PROGRESS_STATUS_FULLY_GRADED //todo pass actual status
             );
         }

--- a/model/execution/LtiContextRepositoryInterface.php
+++ b/model/execution/LtiContextRepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace oat\ltiDeliveryProvider\model\execution;
+
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoLti\models\classes\LtiLaunchData;
+
+interface LtiContextRepositoryInterface
+{
+    public function findByDeliveryExecution(DeliveryExecutionInterface $deliveryExecution): ?LtiLaunchData;
+
+    public function save(LtiLaunchData $ltiLaunchData, DeliveryExecutionInterface $deliveryExecution): void;
+}

--- a/model/execution/implementation/Lti1p3ContextCacheRepository.php
+++ b/model/execution/implementation/Lti1p3ContextCacheRepository.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023  (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\model\execution\implementation;
+
+use oat\ltiDeliveryProvider\model\execution\LtiContextRepositoryInterface;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoLti\models\classes\LtiLaunchData;
+use Psr\Cache\CacheItemPoolInterface;
+
+class Lti1p3ContextCacheRepository implements LtiContextRepositoryInterface
+{
+    private CacheItemPoolInterface $cache;
+
+    private const KEY_PREFIX = 'de_lti1p3context_';
+
+    public function __construct(?CacheItemPoolInterface $cache = null)
+    {
+        $this->cache = $cache;
+    }
+
+    public function findByDeliveryExecution(DeliveryExecutionInterface $deliveryExecution): ?LtiLaunchData
+    {
+
+        $item = $this->cache->getItem($this->buildKey($deliveryExecution->getIdentifier()));
+
+        if ($data = $item->get()) {
+            return LtiLaunchData::fromJsonArray(json_decode($data, true));
+        }
+
+        return null;
+    }
+
+    public function save(LtiLaunchData $ltiLaunchData, DeliveryExecutionInterface $deliveryExecution): void
+    {
+        $key = $this->buildKey($deliveryExecution->getIdentifier());
+        $item = $this->cache->getItem($key);
+
+        $this->cache->save(
+            $item->set(json_encode($ltiLaunchData))
+        );
+    }
+
+    private function buildKey(string $deliveryExecutionId): string
+    {
+        return self::KEY_PREFIX . $deliveryExecutionId;
+    }
+}

--- a/model/serviceProvider/LtiDeliveryServiceProvider.php
+++ b/model/serviceProvider/LtiDeliveryServiceProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\ltiDeliveryProvider\model\serviceProvider;
+
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\ltiDeliveryProvider\model\execution\implementation\Lti1p3ContextCacheRepository;
+use oat\ltiDeliveryProvider\model\execution\LtiContextRepositoryInterface;
+use oat\oatbox\cache\factory\CacheItemPoolFactory;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+class LtiDeliveryServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+        $parameters = $configurator->parameters();
+
+        $services
+            ->set(LtiContextRepositoryInterface::class, Lti1p3ContextCacheRepository::class)
+            ->public()
+            ->args(
+                [
+                    inline_service(CacheItemPoolInterface::class)
+                        ->factory([service(CacheItemPoolFactory::class), 'create'])
+                        ->args([[]])
+                ]
+            );
+    }
+}

--- a/scripts/install/RegisterLtiEvents.php
+++ b/scripts/install/RegisterLtiEvents.php
@@ -27,6 +27,7 @@ use oat\ltiDeliveryProvider\model\events\LtiAgsListener;
 use oat\oatbox\extension\InstallAction;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
+use oat\taoResultServer\models\Events\DeliveryExecutionResultsRecalculated;
 
 class RegisterLtiEvents extends InstallAction
 {
@@ -40,6 +41,11 @@ class RegisterLtiEvents extends InstallAction
         $this->registerEvent(
             DeliveryExecutionState::class,
             [LtiAgsListener::class, 'onDeliveryExecutionStateUpdate']
+        );
+
+        $this->registerEvent(
+            DeliveryExecutionResultsRecalculated::class,
+            [LtiAgsListener::class, 'onDeliveryExecutionResultsRecalculated']
         );
     }
 }

--- a/test/unit/model/Lti1p3ContextCacheRepositoryTest.php
+++ b/test/unit/model/Lti1p3ContextCacheRepositoryTest.php
@@ -39,10 +39,10 @@ class Lti1p3ContextCacheRepositoryTest extends TestCase
         $this->storage = $this->createMock(CacheItemPoolInterface::class);
         $this->subject = new Lti1p3ContextCacheRepository($this->storage);
         $this->launchDataObject = new LtiLaunchData(['key' => 'value'], ['custom_key', 'value']);
-        $this->deliveryExecution = new FakeDeliveryExecution();
+        $this->deliveryExecution = new TestMockDeliveryExecution();
     }
 
-    public function testFindByDeliveryExecution(): void
+    public function testFindByDeliveryExecutionHappyPath(): void
     {
         $cacheItem = $this
             ->createConfiguredMock(
@@ -57,6 +57,21 @@ class Lti1p3ContextCacheRepositoryTest extends TestCase
         $result = $this->subject->findByDeliveryExecution($this->deliveryExecution);
 
         $this->assertEquals($this->launchDataObject, $result);
+    }
+
+    public function testFindByDeliveryExecutionReturnsNull(): void
+    {
+        $cacheItem = $this
+            ->createConfiguredMock(
+                CacheItemInterface::class,
+                ['get' => null]
+            );
+        $this->storage
+            ->expects($this->once())
+            ->method('getItem')
+            ->willReturn($cacheItem);
+
+        $this->assertNull($this->subject->findByDeliveryExecution($this->deliveryExecution));
     }
 
     public function testSave(): void
@@ -82,7 +97,7 @@ class Lti1p3ContextCacheRepositoryTest extends TestCase
 }
 
 // phpcs:ignore
-final class FakeDeliveryExecution implements DeliveryExecutionInterface
+final class TestMockDeliveryExecution implements DeliveryExecutionInterface
 {
     public function getIdentifier()
     {

--- a/test/unit/model/Lti1p3ContextCacheRepositoryTest.php
+++ b/test/unit/model/Lti1p3ContextCacheRepositoryTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023  (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiItem\test\unit\model\import\Repository;
+
+use oat\ltiDeliveryProvider\model\execution\implementation\Lti1p3ContextCacheRepository;
+use oat\oatbox\cache\CacheItem;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoLti\models\classes\LtiLaunchData;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+class Lti1p3ContextCacheRepositoryTest extends TestCase
+{
+    private Lti1p3ContextCacheRepository $subject;
+
+    public function setUp(): void
+    {
+        $this->storage = $this->createMock(CacheItemPoolInterface::class);
+        $this->subject = new Lti1p3ContextCacheRepository($this->storage);
+        $this->launchDataObject = new LtiLaunchData(['key' => 'value'], ['custom_key', 'value']);
+        $this->deliveryExecution = new FakeDeliveryExecution();
+    }
+
+    public function testFindByDeliveryExecution(): void
+    {
+        $cacheItem = $this
+            ->createConfiguredMock(
+                CacheItemInterface::class,
+                ['get' => json_encode($this->launchDataObject)]
+            );
+        $this->storage
+            ->expects($this->once())
+            ->method('getItem')
+            ->willReturn($cacheItem);
+
+        $result = $this->subject->findByDeliveryExecution($this->deliveryExecution);
+
+        $this->assertEquals($this->launchDataObject, $result);
+    }
+
+    public function testSave(): void
+    {
+        $cacheItem = new CacheItem('anykey');
+
+        $this->storage
+            ->expects($this->once())
+            ->method('getItem')
+            ->willReturn($cacheItem);
+
+        $this->storage
+            ->expects($this->once())
+            ->method('save')
+            ->with(
+                $this->callback(function (CacheItemInterface $subjToSave) {
+                    return $subjToSave->get() === json_encode($this->launchDataObject);
+                })
+            );
+
+        $this->subject->save($this->launchDataObject, $this->deliveryExecution);
+    }
+}
+
+// phpcs:ignore
+final class FakeDeliveryExecution implements DeliveryExecutionInterface
+{
+    public function getIdentifier()
+    {
+        return 'test/test#deliveryID';
+    }
+
+    public function getLabel()
+    {
+    }
+
+    public function getStartTime()
+    {
+    }
+
+    public function getFinishTime()
+    {
+    }
+
+    public function getState()
+    {
+    }
+
+    public function setState($state)
+    {
+    }
+
+    public function getDelivery()
+    {
+    }
+
+    public function getUserIdentifier()
+    {
+    }
+}

--- a/test/unit/model/Lti1p3ContextCacheRepositoryTest.php
+++ b/test/unit/model/Lti1p3ContextCacheRepositoryTest.php
@@ -39,7 +39,9 @@ class Lti1p3ContextCacheRepositoryTest extends TestCase
         $this->storage = $this->createMock(CacheItemPoolInterface::class);
         $this->subject = new Lti1p3ContextCacheRepository($this->storage);
         $this->launchDataObject = new LtiLaunchData(['key' => 'value'], ['custom_key', 'value']);
-        $this->deliveryExecution = new TestMockDeliveryExecution();
+        $this->deliveryExecution = $this->createConfiguredMock(DeliveryExecutionInterface::class, [
+            'getIdentifier' => 'test/test#deliveryID'
+        ]);
     }
 
     public function testFindByDeliveryExecutionHappyPath(): void
@@ -93,42 +95,5 @@ class Lti1p3ContextCacheRepositoryTest extends TestCase
             );
 
         $this->subject->save($this->launchDataObject, $this->deliveryExecution);
-    }
-}
-
-// phpcs:ignore
-final class TestMockDeliveryExecution implements DeliveryExecutionInterface
-{
-    public function getIdentifier()
-    {
-        return 'test/test#deliveryID';
-    }
-
-    public function getLabel()
-    {
-    }
-
-    public function getStartTime()
-    {
-    }
-
-    public function getFinishTime()
-    {
-    }
-
-    public function getState()
-    {
-    }
-
-    public function setState($state)
-    {
-    }
-
-    public function getDelivery()
-    {
-    }
-
-    public function getUserIdentifier()
-    {
     }
 }


### PR DESCRIPTION
For https://github.com/oat-sa/extension-tao-outcome/pull/232:
- Aditional event handler to send AGS notification with recalculated scores on demand.
- Repository to store LtiLaunchData for delivery execution in order to get AGS claims for delivery execution without user session.

Dependencies:
- https://github.com/oat-sa/extension-tao-lti/pull/361
