### PR TITLE
fix: Showing "Attempts limits has reached" message when taking a test in TT portal if Max. Executions value is given as empty

### DIFF
--- a/model/LtiAssignment.php
+++ b/model/LtiAssignment.php
@@ -49,14 +49,14 @@ class LtiAssignment extends ConfigurableService
     use OntologyAwareTrait;
     use LoggerAwareTrait;
 
-    const LTI_MAX_ATTEMPTS_VARIABLE = 'custom_max_attempts';
+    public const LTI_MAX_ATTEMPTS_VARIABLE = 'custom_max_attempts';
 
     /**
      * @deprecated Use LtiAssignmentAuthorizationService::SERVICE_ID instead
      */
-    const LTI_SERVICE_ID = 'ltiDeliveryProvider/assignment';
+    public const LTI_SERVICE_ID = 'ltiDeliveryProvider/assignment';
 
-    const SERVICE_ID = 'ltiDeliveryProvider/assignment';
+    public const SERVICE_ID = 'ltiDeliveryProvider/assignment';
 
     /**
      * @param string $deliveryIdentifier

--- a/model/LtiAssignment.php
+++ b/model/LtiAssignment.php
@@ -85,7 +85,7 @@ class LtiAssignment extends ConfigurableService
     protected function verifyToken(KernelResource $delivery, User $user)
     {
         $propMaxExec = $delivery->getOnePropertyValue($this->getProperty(DeliveryContainerService::PROPERTY_MAX_EXEC));
-        $maxExec = is_null($propMaxExec) ? 0 : $propMaxExec->literal;
+        $maxExec = is_null($propMaxExec) ? 0 : (int) $propMaxExec->literal;
 
         $currentSession = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentSession();
 

--- a/test/unit/model/LtiAssignmentTest.php
+++ b/test/unit/model/LtiAssignmentTest.php
@@ -177,7 +177,10 @@ class LtiAssignmentTest extends TestCase
 
         $result = $this->object->isDeliveryExecutionAllowed('URI', $this->userMock);
 
-        $this->assertTrue($result, 'Delivery execution must be allowed when user did less attempts than allowed by LTI custom parameter');
+        $this->assertTrue(
+            $result,
+            'Delivery execution must be allowed when user did less attempts than allowed by LTI custom parameter'
+        );
     }
 
     /**
@@ -288,6 +291,27 @@ class LtiAssignmentTest extends TestCase
         $result = $this->object->isDeliveryExecutionAllowed('URI', $this->userMock);
 
         $this->assertTrue($result, 'Delivery execution must be allowed when user did less attempts than allowed');
+    }
+
+    /**
+     * Test isDeliveryExecutionAllowed when max attempts limit value is empty.
+     */
+    public function testIsDeliveryExecutionAllowedReturnsTrueWhenAttemptsLimitIsEmpty()
+    {
+        $this->deliveryProperties = [
+            DeliveryContainerService::PROPERTY_MAX_EXEC => '',
+            DeliveryAssemblyService::PROPERTY_START => time() - self::TIME_ERROR_MARGIN,
+            DeliveryAssemblyService::PROPERTY_END => time() + self::TIME_ERROR_MARGIN,
+        ];
+
+        $userTokens = [0];
+        $this->attemptServiceMock->expects($this->once())
+            ->method('getAttempts')
+            ->willReturn($userTokens);
+
+        $result = $this->object->isDeliveryExecutionAllowed('URI', $this->userMock);
+
+        $this->assertTrue($result, 'Delivery execution is unlimited when attempts limit is empty');
     }
 
     private function expectAttemptLimitException(): void


### PR DESCRIPTION
In the test-taker portal when launching a test using the username & password created during the  remote publishing, getting the message  “**Attempts limits has reached**” and not being able to take the test, when  Max. Executions (default: unlimited) value is **empty** in TAO application delivery tab for the corresponding test

This issue is due to a change in PHP version from 7.4 to 8.1. Non-strict comparisons between numbers and non-numeric strings now work by casting the number to string and comparing the strings.

How to Test:

1. Login to remote publishing application
2. Import a test
3. Publish the imported test
4. In the delivery tab select the published test
5. Keep Max. Executions(default: unlimited) = '' for the test
6. Do Remote publishing of that test. 
7. Login to Test-taker portal with user data(username & password) generated during remote publishing webhook
8. Select & start a Test
9.  You should able to take the test  (when Max. Executions value is '' or 0 )
10. It shows “**Attempts limits has reached**” message only when Max. Executions value is != '' || 0 and user test attempts limit value is greater than Max. Executions value 

Related ticket - [INV-639](https://oat-sa.atlassian.net/browse/INV-639)





[INV-639]: https://oat-sa.atlassian.net/browse/INV-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ