### PR TITLE
Hotfix/inv 639/delivery max execution limit issue

### DIFF
--- a/model/LtiAssignment.php
+++ b/model/LtiAssignment.php
@@ -49,14 +49,14 @@ class LtiAssignment extends ConfigurableService
     use OntologyAwareTrait;
     use LoggerAwareTrait;
 
-    const LTI_MAX_ATTEMPTS_VARIABLE = 'custom_max_attempts';
+    public const LTI_MAX_ATTEMPTS_VARIABLE = 'custom_max_attempts';
 
     /**
      * @deprecated Use LtiAssignmentAuthorizationService::SERVICE_ID instead
      */
-    const LTI_SERVICE_ID = 'ltiDeliveryProvider/assignment';
+    public const LTI_SERVICE_ID = 'ltiDeliveryProvider/assignment';
 
-    const SERVICE_ID = 'ltiDeliveryProvider/assignment';
+    public const SERVICE_ID = 'ltiDeliveryProvider/assignment';
 
     /**
      * @param string $deliveryIdentifier

--- a/model/LtiAssignment.php
+++ b/model/LtiAssignment.php
@@ -85,7 +85,7 @@ class LtiAssignment extends ConfigurableService
     protected function verifyToken(KernelResource $delivery, User $user)
     {
         $propMaxExec = $delivery->getOnePropertyValue($this->getProperty(DeliveryContainerService::PROPERTY_MAX_EXEC));
-        $maxExec = is_null($propMaxExec) ? 0 : $propMaxExec->literal;
+        $maxExec = is_null($propMaxExec) ? 0 : (int) $propMaxExec->literal;
 
         $currentSession = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentSession();
 

--- a/test/unit/model/LtiAssignmentTest.php
+++ b/test/unit/model/LtiAssignmentTest.php
@@ -177,7 +177,10 @@ class LtiAssignmentTest extends TestCase
 
         $result = $this->object->isDeliveryExecutionAllowed('URI', $this->userMock);
 
-        $this->assertTrue($result, 'Delivery execution must be allowed when user did less attempts than allowed by LTI custom parameter');
+        $this->assertTrue(
+            $result,
+            'Delivery execution must be allowed when user did less attempts than allowed by LTI custom parameter'
+        );
     }
 
     /**
@@ -288,6 +291,27 @@ class LtiAssignmentTest extends TestCase
         $result = $this->object->isDeliveryExecutionAllowed('URI', $this->userMock);
 
         $this->assertTrue($result, 'Delivery execution must be allowed when user did less attempts than allowed');
+    }
+
+    /**
+     * Test isDeliveryExecutionAllowed when max attempts limit value is empty.
+     */
+    public function testIsDeliveryExecutionAllowedReturnsTrueWhenAttemptsLimitIsEmpty()
+    {
+        $this->deliveryProperties = [
+            DeliveryContainerService::PROPERTY_MAX_EXEC => '',
+            DeliveryAssemblyService::PROPERTY_START => time() - self::TIME_ERROR_MARGIN,
+            DeliveryAssemblyService::PROPERTY_END => time() + self::TIME_ERROR_MARGIN,
+        ];
+
+        $userTokens = [0];
+        $this->attemptServiceMock->expects($this->once())
+            ->method('getAttempts')
+            ->willReturn($userTokens);
+
+        $result = $this->object->isDeliveryExecutionAllowed('URI', $this->userMock);
+
+        $this->assertTrue($result, 'Delivery execution is unlimited when attempts limit is empty');
     }
 
     private function expectAttemptLimitException(): void


### PR DESCRIPTION
Version : 12.12.6

Fix: Showing "Attempts limits has reached" message when taking a test in TT portal if Max. Executions value is given as empty
Related ticket - [INV-639](https://oat-sa.atlassian.net/browse/INV-639)