### PR TITLE
fix: pass proper grading status during ags recalculate

### DIFF
--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -94,7 +94,7 @@ class LtiAgsListener extends ConfigurableService
                 $deliveryExecution,
                 $event->getTotalScore(),
                 $event->getTotalMaxScore(),
-                ScoreInterface::GRADING_PROGRESS_STATUS_FULLY_GRADED //todo pass actual status
+                $event->getGradingStatus(),
             );
         }
     }
@@ -178,6 +178,7 @@ class LtiAgsListener extends ConfigurableService
                 'gradingProgress' => $gradingStatus,
                 'scoreGiven' => $scoreTotal,
                 'scoreMaximum' => $scoreTotalMax,
+                'timestamp' => time(),
             ]
         ], $taskLabel);
     }

--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -86,6 +86,10 @@ class LtiAgsListener extends ConfigurableService
     public function onDeliveryExecutionResultsRecalculated(DeliveryExecutionResultsRecalculated $event): void
     {
         $deliveryExecution = $event->getDeliveryExecution();
+        $gradingStatus = ScoreInterface::GRADING_PROGRESS_STATUS_PENDING_MANUAL;
+        if ($event->isFullyGraded()) {
+            $gradingStatus = ScoreInterface::GRADING_PROGRESS_STATUS_FULLY_GRADED;
+        }
 
         if ($launchData = $this->getLtiContextRepository()->findByDeliveryExecution($deliveryExecution)) {
             $this->queueSendAgsScoreTaskWithScores(
@@ -94,7 +98,7 @@ class LtiAgsListener extends ConfigurableService
                 $deliveryExecution,
                 $event->getTotalScore(),
                 $event->getTotalMaxScore(),
-                $event->getGradingStatus(),
+                $gradingStatus
             );
         }
     }

--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -160,7 +160,7 @@ class LtiAgsListener extends ConfigurableService
         $scoreTotal,
         $scoreTotalMax,
         string $gradingStatus,
-        ?string $gradingTimestamp = null
+        ?int $gradingTimestamp = null
     ): void {
 
         if (!$ltiLaunchData->hasVariable(LtiLaunchData::AGS_CLAIMS)) {
@@ -186,7 +186,7 @@ class LtiAgsListener extends ConfigurableService
         ];
 
         if ($gradingTimestamp !== null) {
-            $taskBody['data']['timestamp'] = $gradingTimestamp;
+            $taskBody['data']['timestamp'] = date('Y-m-d H:i:s', $gradingTimestamp);
         }
 
         /** @var QueueDispatcherInterface $taskQueue */


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/INF-183

## What's Changed

- Fixed change of gradingProgress during AGS call

## Dependencies PRs

- https://github.com/oat-sa/extension-tao-outcome/pull/242


## How to test
-Create a test with an item with the SCORE variable manually graded.
-Take the test. The item should have SCORE = 0.
-Hit the API in TR-4956 with send_ags parameter set to true and no request body.
- Check the payload of the AGS notification.