### PR TITLE
feat: use follow redirects switch when sending lti outcome request

### DIFF
--- a/model/tasks/SendLtiOutcomeTask.php
+++ b/model/tasks/SendLtiOutcomeTask.php
@@ -119,7 +119,7 @@ class SendLtiOutcomeTask extends AbstractAction
         //Hack for moodle compatibility, the header is ignored for the signature computation
         $signedRequest->setHeader("Content-Type", "application/xml");
 
-        $response = $signedRequest->send();
+        $response = $signedRequest->send(true);
 
         if ('200' != $response->httpCode) {
             $this->logWarning("Request sent (Body)\n" . $signedRequest->getBody() . "\n");


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/LSI-2325

This one is simply using the switch introduced in oat-sa/generis#1048