### PR TITLE
bugfix: don't truncate milliseconds from timestamp (#363)

### DIFF
--- a/model/tasks/SendAgsScoreTask.php
+++ b/model/tasks/SendAgsScoreTask.php
@@ -47,8 +47,7 @@ class SendAgsScoreTask extends AbstractAction
     public function __invoke($params): Report
     {
         $this->params = array_merge($this->params, $params);
-
-        $this->getLogger()->info('Start AGS score sending task', $params);
+        $this->getLogger()->info('Start AGS score sending task:' . print_r($params, true));
 
         try {
             $this->validateParams($params);


### PR DESCRIPTION
**Backport** of https://github.com/oat-sa/extension-tao-ltideliveryprovider/pull/363/files
----
* bugfix: don't truncate milliseconds from timestamp

* bugfix: pass current timestamp to SendAgsScoreTask

* bugfix: add task body log

* bugfix: add task body log

* bugfix: remove debug

* bugfix: remove debug

* fix: add debug

* fix: add debug

* fix: add debug

* chore: remode debug

* fix: add catch

* fix: add timestamp null check

* fix: remove debug

* fix: remove text

* chore: remove use of Carbon

* fix: add time zone

* fix: remove time zone when using 'now'

* fix: refactor and move format function to Date helper, pass deliveryExecution->getFinishTime() on delivery finish

(cherry picked from commit 6d4255dce3aba7cadd50898c0b5ee6a1ed551ef8)