### PR TITLE
bugfix: move event to proper delivery finish

### DIFF
--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -34,7 +34,7 @@ use oat\tao\model\taskQueue\QueueDispatcherInterface;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
 use oat\taoLti\models\classes\LtiLaunchData;
 use oat\taoLti\models\classes\user\Lti1p3User;
-use oat\taoQtiTest\models\event\TestVariablesRecorded;
+use oat\taoQtiTest\models\event\DeliveryExecutionFinish;
 use oat\taoResultServer\models\Events\DeliveryExecutionResultsRecalculated;
 use tao_helpers_Date as DateHelper;
 use taoResultServer_models_classes_OutcomeVariable as OutcomeVariable;
@@ -89,9 +89,9 @@ class LtiAgsListener extends ConfigurableService
         }
     }
 
-    public function onDeliveryExecutionFinish(TestVariablesRecorded $event): void
+    public function onDeliveryExecutionFinish(DeliveryExecutionFinish $event): void
     {
-        $launchData = $this->getLtiContextRepository()->findByDeliveryExecutionId($event->getDeliveryExecutionId());
+        $launchData = $this->getLtiContextRepository()->findByDeliveryExecutionId($event->getDeliveryExecution()->getIdentifier());
         if (!$launchData) {
             return;
         }
@@ -117,10 +117,14 @@ class LtiAgsListener extends ConfigurableService
             }
         }
 
+        if (!$scoreTotalMicrotime) {
+            $scoreTotalMicrotime = $event->getDeliveryExecution()->getFinishTime();
+        }
+
         $this->queueSendAgsScoreTaskWithScores(
             'AGS score send on test finish',
             $launchData,
-            $event->getDeliveryExecutionId(),
+            $event->getDeliveryExecution()->getIdentifier(),
             $scoreTotal,
             $scoreTotalMax,
             $event->getIsManualScored()

--- a/scripts/install/RegisterLtiEvents.php
+++ b/scripts/install/RegisterLtiEvents.php
@@ -26,7 +26,7 @@ namespace oat\ltiDeliveryProvider\scripts\install;
 use oat\ltiDeliveryProvider\model\events\LtiAgsListener;
 use oat\oatbox\extension\InstallAction;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
-use oat\taoQtiTest\models\event\TestVariablesRecorded;
+use oat\taoQtiTest\models\event\DeliveryExecutionFinish;
 use oat\taoResultServer\models\Events\DeliveryExecutionResultsRecalculated;
 
 class RegisterLtiEvents extends InstallAction
@@ -43,7 +43,7 @@ class RegisterLtiEvents extends InstallAction
             [LtiAgsListener::class, 'onDeliveryExecutionResultsRecalculated']
         );
         $this->registerEvent(
-            TestVariablesRecorded::class,
+            DeliveryExecutionFinish::class,
             [LtiAgsListener::class, 'onDeliveryExecutionFinish']
         );
     }


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/INF-248

## What's Changed

Moving the event to the end of Delivery Execution gives us access to Outcomes and DE Finish time at the same time. We need both of these values to cover the case when a query is sent via the AGS API without changing the result and when the test is set with Outcomes is set to none

## Dependencies PRs

- https://github.com/oat-sa/extension-tao-outcome/pull/273
- https://github.com/oat-sa/extension-tao-testqti/pull/2432