### PR TITLE
feat: Adjust server-side timers when resuming an execution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
 		"oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
 		"oat-sa/extension-tao-lti" : ">=15.11.0",
 		"oat-sa/extension-tao-outcomeui" : ">=10.0.0",
-		"oat-sa/extension-tao-testqti" : ">=48.1.0",
+		"oat-sa/extension-tao-testqti" : "dev-feat/TR-5911-adjust-server-timers-when-resuming-an-execution as >=48.2.2",
 		"oat-sa/extension-tao-outcome" : ">=13.3.0"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
 		"oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
 		"oat-sa/extension-tao-lti" : ">=15.11.0",
 		"oat-sa/extension-tao-outcomeui" : ">=10.0.0",
-		"oat-sa/extension-tao-testqti" : "dev-feat/TR-5911-adjust-server-timers-when-resuming-an-execution as >=48.2.2",
+		"oat-sa/extension-tao-testqti" : ">=48.3.0",
 		"oat-sa/extension-tao-outcome" : ">=13.3.0"
 	}
 }

--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -140,6 +140,10 @@ class DeliveryTool extends ToolModule
 
                         if ($activeExecution instanceof DeliveryExecution) {
                             $this->getConcurringSessionService()->pauseConcurrentSessions($activeExecution);
+
+                            if ($activeExecution->getState()->getUri() === DeliveryExecution::STATE_PAUSED) {
+                                $this->getConcurringSessionService()->adjustTimers($activeExecution);
+                            }
                         }
 
                         $this->resetDeliveryExecutionState($activeExecution);

--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2024 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
 namespace oat\ltiDeliveryProvider\controller;


### PR DESCRIPTION
**Associated Jira issue:** [TR-5911](https://oat-sa.atlassian.net/browse/TR-5911)

This PR adds a call to `adjustTimers` in taoQtiTest when a previously-paused test is launched using an LTI link.

- Related PR: https://github.com/oat-sa/extension-tao-testqti/pull/2438

[TR-5911]: https://oat-sa.atlassian.net/browse/TR-5911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ