### PR TITLE
bugfix: use getIdentifier

### DIFF
--- a/model/events/LtiAgsListener.php
+++ b/model/events/LtiAgsListener.php
@@ -80,7 +80,7 @@ class LtiAgsListener extends ConfigurableService
             $this->queueSendAgsScoreTaskWithScores(
                 'AGS scores send on result recalculation',
                 $launchData,
-                $deliveryExecution->getUserIdentifier(),
+                $deliveryExecution->getIdentifier(),
                 $event->getTotalScore(),
                 $event->getTotalMaxScore(),
                 $gradingStatus,


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/INF-251

## What's Changed

- Remove typo, so use `$deliveryExecution->getIdentifier()` instead of  wrong `$deliveryExecution->getUserIdentifier()` for logs