### PR TITLE
fix: Clear the pause reason for the test being restarted

### DIFF
--- a/controller/DeliveryTool.php
+++ b/controller/DeliveryTool.php
@@ -144,9 +144,12 @@ class DeliveryTool extends ToolModule
                             if ($activeExecution->getState()->getUri() === DeliveryExecution::STATE_PAUSED) {
                                 $this->getConcurringSessionService()->adjustTimers($activeExecution);
                             }
+
+                            $this->getConcurringSessionService()->clearConcurringSession($activeExecution);
                         }
 
                         $this->resetDeliveryExecutionState($activeExecution);
+
                         $this->redirect($this->getLearnerUrl($compiledDelivery, $activeExecution));
                     } catch (QtiTestExtractionFailedException $e) {
                         common_Logger::i($e->getMessage());
@@ -232,7 +235,7 @@ class DeliveryTool extends ToolModule
 
     /**
      * @param core_kernel_classes_Resource $delivery
-     * @param DeliveryExecution            $activeExecution
+     * @param DeliveryExecution|null $activeExecution
      *
      * @return string
      * @throws LtiException


### PR DESCRIPTION
**Associated Jira issue:** [INF-262](https://oat-sa.atlassian.net/browse/INF-262)

Make sure the pause reason associated to a delivery execution is cleared as soon as the execution is (re)started. Otherwise, once the test taker completes the test, the pause reason is still there, which makes the test runner to show a page stating that the test was "paused due to a concurrent session" instead of finished normally.

[INF-262]: https://oat-sa.atlassian.net/browse/INF-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ