### PR TITLE
Fix/oatsd 3174/update how we check delivery

### DIFF
--- a/model/LtiAssignment.php
+++ b/model/LtiAssignment.php
@@ -119,13 +119,13 @@ class LtiAssignment extends ConfigurableService
 
     private function verifyAvailabilityFrame(KernelResource $delivery): void
     {
-        @[[$scheduledStartTimeProperty], [$scheduledEndTimeProperty]] = array_values($delivery->getPropertiesValues(
-            [
-                $this->getProperty(DeliveryAssemblyService::PROPERTY_START),
-                $this->getProperty(DeliveryAssemblyService::PROPERTY_END),
-            ]
-        ));
-
+        $this->logInfo("Verify availability frame for delivery {$delivery->getUri()}");
+        $scheduledStartTimeProperty = $delivery->getOnePropertyValue(
+            $this->getProperty(DeliveryAssemblyService::PROPERTY_START)
+        );
+        $scheduledEndTimeProperty = $delivery->getOnePropertyValue(
+            $this->getProperty(DeliveryAssemblyService::PROPERTY_END)
+        );
         $scheduledStartTime = (int)(string)$scheduledStartTimeProperty ?: 0;
         $scheduledEndTime = (int)(string)$scheduledEndTimeProperty ?: PHP_INT_MAX;
 


### PR DESCRIPTION
Simplify checking deliveries during `verifyAvailabilityFrame`. Potential fix for 
`{"message":"2024-05-02 11:14:43 [ERROR] [tao] 'php error(2): Undefined array key 0' /var/www/html/tao/ltiDeliveryProvider/model/LtiAssignment.php 125","filename":"/var/log/tao/tao.log"}`

How to test:
1. Run a test using LTI
2. No ERRORs