### PR TITLE
feat!: update dependencies for dbal3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,8 @@
   "minimum-stability": "dev",
   "require": {
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "oat-sa/generis": ">=16.2.2",
-    "oat-sa/tao-core": ">=55.0.0",
+    "oat-sa/generis": ">=17.0.0",
+    "oat-sa/tao-core": ">=56.0.0",
     "oat-sa/extension-tao-delivery": ">=15.8.0",
     "oat-sa/extension-tao-delivery-rdf": ">=14.0.0",
     "oat-sa/extension-tao-lti": ">=15.11.0",

--- a/model/LtiResultAliasStorage.php
+++ b/model/LtiResultAliasStorage.php
@@ -104,7 +104,7 @@ class LtiResultAliasStorage extends ConfigurableService implements DeliveryExecu
         $queryBuilder->where('t.' . self::RESULT_ID . '=?');
         $queryBuilder->setParameters([$aliasId]);
         $stmt = $this->persistence->query($queryBuilder->getSQL(), $queryBuilder->getParameters());
-        $data = $stmt->fetch(\PDO::FETCH_ASSOC);
+        $data = $stmt->fetchAssociative();
         return isset($data[self::DELIVERY_EXECUTION_ID])
             ? $data[self::DELIVERY_EXECUTION_ID]
             : $aliasId;

--- a/test/integration/model/LtiResultAliasStorageTest.php
+++ b/test/integration/model/LtiResultAliasStorageTest.php
@@ -97,7 +97,7 @@ class LtiResultAliasStorageTest extends TestCase
         $storage = new LtiResultAliasStorage([
             LtiResultAliasStorage::OPTION_PERSISTENCE => 'test_LtiResultIdStorageTest'
         ]);
-        $config = new \common_persistence_KeyValuePersistence([], new \common_persistence_InMemoryKvDriver());
+        $config = new \common_persistence_KeyValuePersistence(new \common_persistence_InMemoryKvDriver(), []);
         $config->set(\common_persistence_Manager::SERVICE_ID, $persistenceManager);
         $serviceManager = new ServiceManager($config);
         $storage->setServiceManager($serviceManager);


### PR DESCRIPTION
Update dependencies with DBAL3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated minimum required versions for core dependencies: Generis (>=17.0.0) and TAO Core (>=56.0.0) for compatibility.

* **Tests**
  * Adjusted integration test setup for key-value persistence initialization to match updated constructor argument ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->