### PR TITLE
fix: align lti delivery link tree action weight

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -5,7 +5,7 @@
         <sections>
             <section id="manage_delivery_assembly" name="Deliveries" url="/taoDeliveryRdf/DeliveryMgmt/index">
                 <actions>
-                    <action id="lti-delivery-link" name="LTI" url="/ltiDeliveryProvider/DeliveryLinks/index" context="instance" group="tree">
+                    <action id="lti-delivery-link" name="LTI" url="/ltiDeliveryProvider/DeliveryLinks/index" context="instance" group="tree" weight="6">
                         <icon id="icon-link"/>
                     </action>
                 </actions>


### PR DESCRIPTION
## Summary
- add explicit weight for `lti-delivery-link` tree action to preserve merged delivery tree ordering with Quick Wins sorting

## Validation
- cleared cache with `rm -Rf data/generis/cache/*`
- verified delivery tree order in runtime checks
